### PR TITLE
Memory+

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,24 @@ Linux/MacOS   [![Build Status](https://travis-ci.org/Equilibrium-Games/Flounder.
 # Code snippets
 ```cpp
 // Imports a 2D texture.
-Texture *guiBlack = Texture::Resource("Resources/Guis/Black.png");
+auto guiBlack = Texture::Resource("Resources/Guis/Black.png");
 
 // Imports a 3D cubemap.
-Cubemap *skyboxSnowy = Cubemap::Resource("Resources/Objects/SkyboxSnowy", ".png");
+auto skyboxSnowy = Cubemap::Resource("Resources/Objects/SkyboxSnowy", ".png");
 
 // Imports a model.
-Model *dragon = Model::Resource("Resources/Objects/Testing/Model_Dragon.obj");
+auto dragon = Model::Resource("Resources/Objects/Testing/Model_Dragon.obj");
 
 // Plays a 3D sound, at the origin, at half volume.
-Sound jump = Sound("Resources/Sounds/Jump.ogg", 0.5f);
+auto jump = Sound("Resources/Sounds/Jump.ogg", 0.5f);
 jump.SetPosition(Vector3::ZERO);
 jump.Play();
 
 // Imports a game object.
-GameObject *playerObject = new GameObject("Player", Transform());
+auto playerObject = new GameObject("Player", Transform());
 
 // Creates a game object.
-GameObject *sphere = new GameObject(Transform(Vector3(6.7f, 6.7f, -8.0f), Vector3(), 3.0f));
+auto sphere = new GameObject(Transform(Vector3(6.7f, 6.7f, -8.0f), Vector3(), 3.0f));
 sphere->AddComponent<Mesh>(ShapeSphere::Resource(30, 30, 1.0f));
 sphere->AddComponent<MaterialDefault>(Colour::WHITE, Texture::Resource("Resources/Objects/Testing/Diffuse.png"),
     0.0f, 0.0f, Texture::Resource("Resources/Objects/Testing/Material.png"), Texture::Resource("Resources/Objects/Testing/Normal.png"));

--- a/Resources/Shaders/Animated/Animated.vert
+++ b/Resources/Shaders/Animated/Animated.vert
@@ -30,15 +30,12 @@ out gl_PerVertex
 
 void main() 
 {
-	//vec4 totalLocalPos = vec4(vertexPosition, 1.0f);
-	//vec4 totalNormal = vec4(vertexNormal, 0.0f);
-
 	vec4 totalLocalPos = vec4(0.0f);
 	vec4 totalNormal = vec4(0.0f);
 
     for (int i = 0; i < MAX_WEIGHTS; i++)
     {
-        mat4 jointTransform = object.jointTransforms[ivec3(vertexJointIndices)[i]];
+        mat4 jointTransform = object.jointTransforms[int(vertexJointIndices[i])];
         vec4 posePosition = jointTransform * vec4(vertexPosition, 1.0);
         totalLocalPos += posePosition * vertexWeights[i];
 

--- a/Sources/Animations/Animation/Animation.cpp
+++ b/Sources/Animations/Animation/Animation.cpp
@@ -14,7 +14,7 @@ namespace fl
 	{
 		for (auto frameData : keyframeData)
 		{
-			m_keyframes.push_back(new Keyframe(*frameData));
+			m_keyframes.emplace_back(new Keyframe(*frameData));
 		}
 	}
 

--- a/Sources/Animations/Animation/Animation.cpp
+++ b/Sources/Animations/Animation/Animation.cpp
@@ -4,27 +4,25 @@ namespace fl
 {
 	Animation::Animation(const float &length, const std::vector<Keyframe *> &keyframes) :
 		m_length(length),
-		m_keyframes(new std::vector<Keyframe *>(keyframes))
+		m_keyframes(keyframes)
 	{
 	}
 
 	Animation::Animation(const float &length, const std::vector<KeyframeData *> &keyframeData) :
 		m_length(length),
-		m_keyframes(new std::vector<Keyframe *>())
+		m_keyframes(std::vector<Keyframe *>())
 	{
 		for (auto frameData : keyframeData)
 		{
-			m_keyframes->push_back(new Keyframe(*frameData));
+			m_keyframes.push_back(new Keyframe(*frameData));
 		}
 	}
 
 	Animation::~Animation()
 	{
-		for (auto keyFrame : *m_keyframes)
+		for (auto keyFrame : m_keyframes)
 		{
 			delete keyFrame;
 		}
-
-		delete m_keyframes;
 	}
 }

--- a/Sources/Animations/Animation/Animation.hpp
+++ b/Sources/Animations/Animation/Animation.hpp
@@ -14,7 +14,7 @@ namespace fl
 	private:
 		float m_length;
 
-		std::vector<Keyframe *> *m_keyframes;
+		std::vector<Keyframe *> m_keyframes;
 	public:
 		/// <summary>
 		/// Creates a new animation.
@@ -38,6 +38,6 @@ namespace fl
 		/// keyframes in the animation (first keyframe of the animation in array position 0).
 		/// </summary>
 		/// <returns> The array of the animation's keyframes. </returns>
-		std::vector<Keyframe *> *GetKeyframes() const { return m_keyframes; }
+		std::vector<Keyframe *> GetKeyframes() const { return m_keyframes; }
 	};
 }

--- a/Sources/Animations/Animation/AnimationLoader.cpp
+++ b/Sources/Animations/Animation/AnimationLoader.cpp
@@ -59,7 +59,7 @@ namespace fl
 	{
 		for (auto time : times)
 		{
-			m_keyframeData.push_back(new KeyframeData(time));
+			m_keyframeData.emplace_back(new KeyframeData(time));
 		}
 	}
 

--- a/Sources/Animations/Animation/AnimationLoader.cpp
+++ b/Sources/Animations/Animation/AnimationLoader.cpp
@@ -13,7 +13,7 @@ namespace fl
 		auto animationNodes = m_libraryAnimations->GetChild("animation")->GetChildren();
 
 		std::string rootNode = FindRootJointName();
-		std::vector<float> times = GetKeyTimes();
+		auto times = GetKeyTimes();
 		m_lengthSeconds = times[times.size() - 1];
 		CreateKeyframeData(times);
 
@@ -86,22 +86,21 @@ namespace fl
 	{
 		auto channelNode = jointData->GetChild("channel");
 		std::string data = channelNode->GetChild("-target")->GetString();
-		std::vector<std::string> splitData = FormatString::Split(data, "/");
+		auto splitData = FormatString::Split(data, "/");
 		return splitData[0];
 	}
 
 	void AnimationLoader::ProcessTransforms(const std::string &jointName, const std::vector<std::string> &rawData, const bool &root)
 	{
-		float *matrixData = new float[16];
-
 		for (unsigned int i = 0; i < m_keyframeData.size(); i++)
 		{
+			Matrix4 transform = Matrix4();
+
 			for (unsigned int j = 0; j < 16; j++)
 			{
-				matrixData[j] = std::stof(rawData[i * 16 + j]);
+				transform.m_linear[j] = std::stof(rawData[i * 16 + j]);
 			}
 
-			Matrix4 transform = Matrix4(matrixData);
 			transform = transform.Transpose();
 
 			if (root)
@@ -112,7 +111,5 @@ namespace fl
 
 			m_keyframeData[i]->AddJointTransform(new JointTransformData(jointName, transform));
 		}
-
-		delete[] matrixData;
 	}
 }

--- a/Sources/Animations/Animation/AnimationLoader.cpp
+++ b/Sources/Animations/Animation/AnimationLoader.cpp
@@ -106,7 +106,7 @@ namespace fl
 			if (root)
 			{
 				// Because up axis in Blender is different to up axis in game.
-				transform *= *MeshAnimated::CORRECTION;
+				transform *= MeshAnimated::CORRECTION;
 			}
 
 			m_keyframeData[i]->AddJointTransform(new JointTransformData(jointName, transform));

--- a/Sources/Animations/Animation/AnimationLoader.cpp
+++ b/Sources/Animations/Animation/AnimationLoader.cpp
@@ -107,7 +107,7 @@ namespace fl
 			if (root)
 			{
 				// Because up axis in Blender is different to up axis in game.
-				transform *= *MeshAnimated::S_CORRECTION;
+				transform *= *MeshAnimated::CORRECTION;
 			}
 
 			m_keyframeData[i]->AddJointTransform(new JointTransformData(jointName, transform));

--- a/Sources/Animations/Animator.cpp
+++ b/Sources/Animations/Animator.cpp
@@ -51,19 +51,19 @@ namespace fl
 	std::vector<Keyframe *> Animator::GetPreviousAndNextFrames()
 	{
 		auto allFrames = m_currentAnimation->GetKeyframes();
-		Keyframe *previousFrame = allFrames->at(0);
-		Keyframe *nextFrame = allFrames->at(0);
+		Keyframe *previousFrame = allFrames[0];
+		Keyframe *nextFrame = allFrames[0];
 
-		for (unsigned int i = 1; i < allFrames->size(); i++)
+		for (unsigned int i = 1; i < allFrames.size(); i++)
 		{
-			nextFrame = allFrames->at(i);
+			nextFrame = allFrames[i];
 
 			if (nextFrame->GetTimeStamp() > m_animationTime)
 			{
 				break;
 			}
 
-			previousFrame = allFrames->at(i);
+			previousFrame = allFrames[i];
 		}
 
 		return {previousFrame, nextFrame};
@@ -80,10 +80,10 @@ namespace fl
 	{
 		auto currentPose = std::map<std::string, Matrix4>();
 
-		for (auto joint : *previousFrame.GetPose())
+		for (auto joint : previousFrame.GetPose())
 		{
-			JointTransform *previousTransform = previousFrame.GetPose()->find(joint.first)->second;
-			JointTransform *nextTransform = nextFrame.GetPose()->find(joint.first)->second;
+			JointTransform *previousTransform = previousFrame.GetPose().find(joint.first)->second;
+			JointTransform *nextTransform = nextFrame.GetPose().find(joint.first)->second;
 			JointTransform currentTransform = JointTransform::Interpolate(*previousTransform, *nextTransform, progression);
 			currentPose.insert(std::make_pair(joint.first, currentTransform.GetLocalTransform()));
 		}
@@ -96,12 +96,12 @@ namespace fl
 		Matrix4 currentLocalTransform = currentPose.find(joint->GetName())->second;
 		Matrix4 currentTransform = parentTransform * currentLocalTransform;
 
-		for (auto childJoint : *joint->GetChildren())
+		for (auto childJoint : joint->GetChildren())
 		{
 			ApplyPoseToJoints(currentPose, childJoint, currentTransform);
 		}
 
-		currentTransform = currentTransform * *joint->GetInverseBindTransform();
+		currentTransform = currentTransform * joint->GetInverseBindTransform();
 		joint->SetAnimatedTransform(currentTransform);
 	}
 

--- a/Sources/Animations/Animator.cpp
+++ b/Sources/Animations/Animator.cpp
@@ -85,7 +85,7 @@ namespace fl
 			JointTransform *previousTransform = previousFrame.GetPose().find(joint.first)->second;
 			JointTransform *nextTransform = nextFrame.GetPose().find(joint.first)->second;
 			JointTransform currentTransform = JointTransform::Interpolate(*previousTransform, *nextTransform, progression);
-			currentPose.insert(std::make_pair(joint.first, currentTransform.GetLocalTransform()));
+			currentPose.emplace(joint.first, currentTransform.GetLocalTransform());
 		}
 
 		return currentPose;

--- a/Sources/Animations/Geometry/GeometryLoader.cpp
+++ b/Sources/Animations/Geometry/GeometryLoader.cpp
@@ -52,7 +52,7 @@ namespace fl
 		for (unsigned int i = 0; i < positionsCount / 3; i++)
 		{
 			Vector4 position = Vector4(std::stof(positionsRawData[i * 3]), std::stof(positionsRawData[i * 3 + 1]), std::stof(positionsRawData[i * 3 + 2]), 1.0f);
-			position = MeshAnimated::S_CORRECTION->Transform(position); // FIXME: Multiply?
+			position = MeshAnimated::CORRECTION->Transform(position); // FIXME: Multiply?
 			VertexAnimatedData *newVertex = new VertexAnimatedData(m_positionsList.size(), position);
 			newVertex->SetSkinData(m_vertexWeights[m_positionsList.size()]);
 			m_positionsList.push_back(newVertex);
@@ -83,7 +83,7 @@ namespace fl
 		for (unsigned int i = 0; i < normalsCount / 3; i++)
 		{
 			Vector3 normal = Vector3(std::stof(normalsRawData[i * 3]), std::stof(normalsRawData[i * 3 + 1]), std::stof(normalsRawData[i * 3 + 2]));
-			normal = MeshAnimated::S_CORRECTION->Transform(normal); // FIXME: Multiply?
+			normal = MeshAnimated::CORRECTION->Transform(normal); // FIXME: Multiply?
 			m_normalsList.push_back(normal);
 		}
 	}

--- a/Sources/Animations/Geometry/GeometryLoader.cpp
+++ b/Sources/Animations/Geometry/GeometryLoader.cpp
@@ -52,7 +52,7 @@ namespace fl
 		for (unsigned int i = 0; i < positionsCount / 3; i++)
 		{
 			Vector4 position = Vector4(std::stof(positionsRawData[i * 3]), std::stof(positionsRawData[i * 3 + 1]), std::stof(positionsRawData[i * 3 + 2]), 1.0f);
-			position = MeshAnimated::CORRECTION->Transform(position); // FIXME: Multiply?
+			position = MeshAnimated::CORRECTION.Transform(position);
 			VertexAnimatedData *newVertex = new VertexAnimatedData(m_positionsList.size(), position);
 			newVertex->SetSkinData(m_vertexWeights[m_positionsList.size()]);
 			m_positionsList.push_back(newVertex);
@@ -83,7 +83,7 @@ namespace fl
 		for (unsigned int i = 0; i < normalsCount / 3; i++)
 		{
 			Vector3 normal = Vector3(std::stof(normalsRawData[i * 3]), std::stof(normalsRawData[i * 3 + 1]), std::stof(normalsRawData[i * 3 + 2]));
-			normal = MeshAnimated::CORRECTION->Transform(normal); // FIXME: Multiply?
+			normal = MeshAnimated::CORRECTION.Transform(normal);
 			m_normalsList.push_back(normal);
 		}
 	}

--- a/Sources/Animations/Geometry/GeometryLoader.cpp
+++ b/Sources/Animations/Geometry/GeometryLoader.cpp
@@ -32,7 +32,7 @@ namespace fl
 
 			VertexAnimated *vertex = new VertexAnimated(position, textures, normal, tangent, jointIds, weights);
 
-			m_vertices.push_back(vertex);
+			m_vertices.emplace_back(vertex);
 
 			delete current;
 		}
@@ -55,7 +55,7 @@ namespace fl
 			position = MeshAnimated::CORRECTION.Transform(position);
 			VertexAnimatedData *newVertex = new VertexAnimatedData(m_positionsList.size(), position);
 			newVertex->SetSkinData(m_vertexWeights[m_positionsList.size()]);
-			m_positionsList.push_back(newVertex);
+			m_positionsList.emplace_back(newVertex);
 		}
 	}
 
@@ -69,7 +69,7 @@ namespace fl
 		for (unsigned int i = 0; i < uvsCount / 2; i++)
 		{
 			Vector2 uv = Vector2(std::stof(uvsRawData[i * 2]), 1.0f - std::stof(uvsRawData[i * 2 + 1]));
-			m_uvsList.push_back(uv);
+			m_uvsList.emplace_back(uv);
 		}
 	}
 
@@ -84,7 +84,7 @@ namespace fl
 		{
 			Vector3 normal = Vector3(std::stof(normalsRawData[i * 3]), std::stof(normalsRawData[i * 3 + 1]), std::stof(normalsRawData[i * 3 + 2]));
 			normal = MeshAnimated::CORRECTION.Transform(normal);
-			m_normalsList.push_back(normal);
+			m_normalsList.emplace_back(normal);
 		}
 	}
 
@@ -110,7 +110,7 @@ namespace fl
 		{
 			currentVertex->SetUvIndex(uvIndex);
 			currentVertex->SetNormalIndex(normalIndex);
-			m_indices.push_back(positionIndex);
+			m_indices.emplace_back(positionIndex);
 			return currentVertex;
 		}
 		else
@@ -123,7 +123,7 @@ namespace fl
 	{
 		if (previousVertex->HasSameTextureAndNormal(newUvIndex, newNormalIndex))
 		{
-			m_indices.push_back(previousVertex->GetIndex());
+			m_indices.emplace_back(previousVertex->GetIndex());
 			return previousVertex;
 		}
 		else
@@ -150,8 +150,8 @@ namespace fl
 				duplicateVertex->SetNormalIndex(newNormalIndex);
 				duplicateVertex->SetSkinData(previousVertex->GetSkinData());
 				previousVertex->SetDuplicateVertex(duplicateVertex);
-				m_positionsList.push_back(duplicateVertex);
-				m_indices.push_back(duplicateVertex->GetIndex());
+				m_positionsList.emplace_back(duplicateVertex);
+				m_indices.emplace_back(duplicateVertex->GetIndex());
 				return duplicateVertex;
 			}
 		}

--- a/Sources/Animations/Geometry/VertexAnimated.cpp
+++ b/Sources/Animations/Geometry/VertexAnimated.cpp
@@ -37,7 +37,7 @@ namespace fl
 
 		for (auto vertex : vertices)
 		{
-			thisVector.push_back(*((VertexAnimated *) vertex));
+			thisVector.emplace_back(*((VertexAnimated *) vertex));
 		}
 
 		memcpy(data, thisVector.data(), dataSize);

--- a/Sources/Animations/Geometry/VertexAnimated.hpp
+++ b/Sources/Animations/Geometry/VertexAnimated.hpp
@@ -19,7 +19,7 @@ namespace fl
 		Vector3 m_jointId;
 		Vector3 m_vertexWeight;
 
-		VertexAnimated(const Vector3 &position = Vector3(), const Vector2 &uv = Vector2(), const Vector3 &normal = Vector3(), const Vector3 &tangent = Vector3(), const Vector3 &jointId = Vector3(), const Vector3 &vertexWeight = Vector3());
+		VertexAnimated(const Vector3 &position = Vector3::ZERO, const Vector2 &uv = Vector2::ZERO, const Vector3 &normal = Vector3::ZERO, const Vector3 &tangent = Vector3::ZERO, const Vector3 &jointId = Vector3::ZERO, const Vector3 &vertexWeight = Vector3::ZERO);
 
 		VertexAnimated(const VertexAnimated &source);
 

--- a/Sources/Animations/Geometry/VertexAnimatedData.cpp
+++ b/Sources/Animations/Geometry/VertexAnimatedData.cpp
@@ -23,7 +23,7 @@ namespace fl
 
 	void VertexAnimatedData::AddTangent(Vector3 *tangent)
 	{
-		m_tangents.push_back(tangent);
+		m_tangents.emplace_back(tangent);
 	}
 
 	void VertexAnimatedData::AverageTangents()

--- a/Sources/Animations/Geometry/VertexAnimatedData.cpp
+++ b/Sources/Animations/Geometry/VertexAnimatedData.cpp
@@ -19,7 +19,6 @@ namespace fl
 
 	VertexAnimatedData::~VertexAnimatedData()
 	{
-		//	delete m_duplicateVertex;
 	}
 
 	void VertexAnimatedData::AddTangent(Vector3 *tangent)
@@ -36,7 +35,7 @@ namespace fl
 
 		for (auto it = m_tangents.begin(); it < m_tangents.end(); ++it)
 		{
-			m_averagedTangent += **it;
+			m_averagedTangent += *(*it);
 		}
 
 		if (m_averagedTangent.Length() > 0.0f)

--- a/Sources/Animations/Joint/Joint.cpp
+++ b/Sources/Animations/Joint/Joint.cpp
@@ -5,33 +5,27 @@ namespace fl
 	Joint::Joint(const int &index, const std::string &name, const Matrix4 &bindLocalTransform) :
 		m_index(index),
 		m_name(name),
-		m_children(new std::vector<Joint *>()),
-		m_localBindTransform(new Matrix4(bindLocalTransform)),
-		m_animatedTransform(new Matrix4()),
-		m_inverseBindTransform(new Matrix4())
+		m_children(std::vector<Joint *>()),
+		m_localBindTransform(Matrix4(bindLocalTransform)),
+		m_animatedTransform(Matrix4()),
+		m_inverseBindTransform(Matrix4())
 	{
 	}
 
 	Joint::~Joint()
 	{
-		for (auto child : *m_children)
+		for (auto child : m_children)
 		{
 			delete child;
 		}
-
-		delete m_children;
-
-		delete m_localBindTransform;
-		delete m_animatedTransform;
-		delete m_inverseBindTransform;
 	}
 
 	void Joint::CalculateInverseBindTransform(const Matrix4 &parentBindTransform)
 	{
-		Matrix4 bindTransform = parentBindTransform * *m_localBindTransform;
-		*m_inverseBindTransform = bindTransform.Invert();
+		Matrix4 bindTransform = parentBindTransform * m_localBindTransform;
+		m_inverseBindTransform = bindTransform.Invert();
 
-		for (auto child : *m_children)
+		for (auto child : m_children)
 		{
 			child->CalculateInverseBindTransform(bindTransform);
 		}
@@ -39,7 +33,7 @@ namespace fl
 
 	void Joint::AddChild(Joint *child)
 	{
-		m_children->push_back(child);
+		m_children.push_back(child);
 	}
 
 	void Joint::AddSelfAndChildren(std::vector<Joint *> *children)

--- a/Sources/Animations/Joint/Joint.cpp
+++ b/Sources/Animations/Joint/Joint.cpp
@@ -33,12 +33,12 @@ namespace fl
 
 	void Joint::AddChild(Joint *child)
 	{
-		m_children.push_back(child);
+		m_children.emplace_back(child);
 	}
 
 	void Joint::AddSelfAndChildren(std::vector<Joint *> *children)
 	{
-		children->push_back(this);
+		children->emplace_back(this);
 
 		for (auto child : *children)
 		{

--- a/Sources/Animations/Joint/Joint.hpp
+++ b/Sources/Animations/Joint/Joint.hpp
@@ -29,12 +29,11 @@ namespace fl
 	private:
 		int m_index;
 		std::string m_name;
-		std::vector<Joint *> *m_children;
+		std::vector<Joint *> m_children;
 
-		Matrix4 *m_localBindTransform;
-		Matrix4 *m_animatedTransform;
-		Matrix4 *m_inverseBindTransform;
-
+		Matrix4 m_localBindTransform;
+		Matrix4 m_animatedTransform;
+		Matrix4 m_inverseBindTransform;
 	public:
 		/// <summary>
 		/// Creates a new joint.
@@ -70,7 +69,7 @@ namespace fl
 
 		void SetName(const std::string &name) { m_name = name; }
 
-		std::vector<Joint *> *GetChildren() const { return m_children; }
+		std::vector<Joint *> GetChildren() const { return m_children; }
 
 		/// <summary>
 		/// Adds a child joint to this joint. Used during the creation of the joint hierarchy. Joints can have multiple children,
@@ -85,9 +84,9 @@ namespace fl
 		/// <param name="joints"> The array to add this and children into. </param>
 		void AddSelfAndChildren(std::vector<Joint *> *children);
 
-		Matrix4 *GetLocalBindTransform() const { return m_localBindTransform; }
+		Matrix4 GetLocalBindTransform() const { return m_localBindTransform; }
 
-		void SetLocalBindTransform(const Matrix4 &localBindTransform) { *m_localBindTransform = localBindTransform; }
+		void SetLocalBindTransform(const Matrix4 &localBindTransform) { m_localBindTransform = localBindTransform; }
 
 		/// <summary>
 		/// The animated transform is the transform that gets loaded up to the shader and is used to deform the vertices of the "skin". It represents the
@@ -95,9 +94,9 @@ namespace fl
 		/// This matrix is calculated by taking the desired model-space transform of the joint and multiplying it by the inverse of the starting model-space transform of the joint.
 		/// </summary>
 		/// <returns> The transformation matrix of the joint which is used to deform associated vertices of the skin in the shaders. </returns>
-		Matrix4 *GetAnimatedTransform() const { return m_animatedTransform; }
+		Matrix4 GetAnimatedTransform() const { return m_animatedTransform; }
 
-		void SetAnimatedTransform(const Matrix4 &animatedTransform) { *m_animatedTransform = animatedTransform; }
+		void SetAnimatedTransform(const Matrix4 &animatedTransform) { m_animatedTransform = animatedTransform; }
 
 		/// <summary>
 		/// This returns the inverted model-space bind transform.
@@ -105,8 +104,8 @@ namespace fl
 		/// This returns the inverse of that, which is used to calculate the animated transform matrix which gets used to transform vertices in the shader.
 		/// </summary>
 		/// <returns> The inverse of the joint's bind transform (in model-space). </returns>
-		Matrix4 *GetInverseBindTransform() const { return m_inverseBindTransform; }
+		Matrix4 GetInverseBindTransform() const { return m_inverseBindTransform; }
 
-		void SetInverseBindTransform(const Matrix4 &inverseBindTransform) { *m_inverseBindTransform = inverseBindTransform; }
+		void SetInverseBindTransform(const Matrix4 &inverseBindTransform) { m_inverseBindTransform = inverseBindTransform; }
 	};
 }

--- a/Sources/Animations/Joint/JointData.cpp
+++ b/Sources/Animations/Joint/JointData.cpp
@@ -20,6 +20,6 @@ namespace fl
 
 	void JointData::AddChild(JointData *child)
 	{
-		m_children.push_back(child);
+		m_children.emplace_back(child);
 	}
 }

--- a/Sources/Animations/Joint/JointTransform.cpp
+++ b/Sources/Animations/Joint/JointTransform.cpp
@@ -3,42 +3,40 @@
 namespace fl
 {
 	JointTransform::JointTransform(const Vector3 &position, const Quaternion &rotation) :
-		m_position(new Vector3(position)),
-		m_rotation(new Quaternion(rotation))
+		m_position(Vector3(position)),
+		m_rotation(Quaternion(rotation))
 	{
 	}
 
 	JointTransform::JointTransform(const Matrix4 &localTransform) :
-		m_position(new Vector3(localTransform.m_30, localTransform.m_31, localTransform.m_32)),
-		m_rotation(new Quaternion(localTransform))
+		m_position(Vector3(localTransform.m_30, localTransform.m_31, localTransform.m_32)),
+		m_rotation(Quaternion(localTransform))
 	{
 	}
 
 	JointTransform::JointTransform(const JointTransformData &data) :
-		m_position(new Vector3(data.GetJointLocalTransform()->m_30, data.GetJointLocalTransform()->m_31, data.GetJointLocalTransform()->m_32)),
-		m_rotation(new Quaternion(*data.GetJointLocalTransform()))
+		m_position(Vector3(data.GetJointLocalTransform().m_30, data.GetJointLocalTransform().m_31, data.GetJointLocalTransform().m_32)),
+		m_rotation(Quaternion(data.GetJointLocalTransform()))
 	{
 	}
 
 	JointTransform::~JointTransform()
 	{
-		delete m_position;
-		delete m_rotation;
 	}
 
 	Matrix4 JointTransform::GetLocalTransform()
 	{
-		Matrix4 rotationMatrix = m_rotation->ToRotationMatrix();
+		Matrix4 rotationMatrix = m_rotation.ToRotationMatrix();
 		Matrix4 matrix = Matrix4();
-		matrix = matrix.Translate(*m_position);
+		matrix = matrix.Translate(m_position);
 		matrix *= rotationMatrix;
 		return matrix;
 	}
 
 	JointTransform JointTransform::Interpolate(const JointTransform &frameA, const JointTransform &frameB, const float &progression)
 	{
-		Vector3 pos = Interpolate(*frameA.GetPosition(), *frameB.GetPosition(), progression);
-		Quaternion rot = frameA.GetRotation()->Slerp(*frameB.GetRotation(), progression);
+		Vector3 pos = Interpolate(frameA.GetPosition(), frameB.GetPosition(), progression);
+		Quaternion rot = frameA.GetRotation().Slerp(frameB.GetRotation(), progression);
 		return JointTransform(pos, rot);
 	}
 

--- a/Sources/Animations/Joint/JointTransform.hpp
+++ b/Sources/Animations/Joint/JointTransform.hpp
@@ -15,8 +15,8 @@ namespace fl
 	class FL_EXPORT JointTransform
 	{
 	private:
-		Vector3 *m_position;
-		Quaternion *m_rotation;
+		Vector3 m_position;
+		Quaternion m_rotation;
 
 	public:
 		/// <summary>
@@ -69,12 +69,12 @@ namespace fl
 		/// <returns> The interpolated progressed vector. </returns>
 		static Vector3 Interpolate(const Vector3 &start, const Vector3 &end, const float &progression);
 
-		Vector3 *GetPosition() const { return m_position; }
+		Vector3 GetPosition() const { return m_position; }
 
-		void SetPosition(const Vector3 &position) { *m_position = position; }
+		void SetPosition(const Vector3 &position) { m_position = position; }
 
-		Quaternion *GetRotation() const { return m_rotation; }
+		Quaternion GetRotation() const { return m_rotation; }
 
-		void SetRotation(const Quaternion &rotation) { *m_rotation = rotation; }
+		void SetRotation(const Quaternion &rotation) { m_rotation = rotation; }
 	};
 }

--- a/Sources/Animations/Joint/JointTransformData.cpp
+++ b/Sources/Animations/Joint/JointTransformData.cpp
@@ -4,12 +4,11 @@ namespace fl
 {
 	JointTransformData::JointTransformData(const std::string &jointNameId, const Matrix4 &jointLocalTransform) :
 		m_jointNameId(jointNameId),
-		m_jointLocalTransform(new Matrix4(jointLocalTransform))
+		m_jointLocalTransform(Matrix4(jointLocalTransform))
 	{
 	}
 
 	JointTransformData::~JointTransformData()
 	{
-		delete m_jointLocalTransform;
 	}
 }

--- a/Sources/Animations/Joint/JointTransformData.hpp
+++ b/Sources/Animations/Joint/JointTransformData.hpp
@@ -9,7 +9,7 @@ namespace fl
 	{
 	private:
 		std::string m_jointNameId;
-		Matrix4 *m_jointLocalTransform;
+		Matrix4 m_jointLocalTransform;
 	public:
 		JointTransformData(const std::string &jointNameId, const Matrix4 &jointLocalTransform);
 
@@ -17,6 +17,6 @@ namespace fl
 
 		std::string GetJointNameId() const { return m_jointNameId; }
 
-		Matrix4 *GetJointLocalTransform() const { return m_jointLocalTransform; }
+		Matrix4 GetJointLocalTransform() const { return m_jointLocalTransform; }
 	};
 }

--- a/Sources/Animations/Keyframe/Keyframe.cpp
+++ b/Sources/Animations/Keyframe/Keyframe.cpp
@@ -14,7 +14,7 @@ namespace fl
 	{
 		for (auto jointData : data.GetJointTransforms())
 		{
-			m_pose.insert(std::make_pair(jointData->GetJointNameId(), new JointTransform(*jointData)));
+			m_pose.emplace(jointData->GetJointNameId(), new JointTransform(*jointData));
 		}
 	}
 

--- a/Sources/Animations/Keyframe/Keyframe.cpp
+++ b/Sources/Animations/Keyframe/Keyframe.cpp
@@ -4,27 +4,25 @@ namespace fl
 {
 	Keyframe::Keyframe(const float &timeStamp, const std::map<std::string, JointTransform *> &pose) :
 		m_timeStamp(timeStamp),
-		m_pose(new std::map<std::string, JointTransform *>(pose))
+		m_pose(std::map<std::string, JointTransform *>(pose))
 	{
 	}
 
 	Keyframe::Keyframe(const KeyframeData &data) :
 		m_timeStamp(data.GetTime()),
-		m_pose(new std::map<std::string, JointTransform *>())
+		m_pose(std::map<std::string, JointTransform *>())
 	{
 		for (auto jointData : data.GetJointTransforms())
 		{
-			m_pose->insert(std::make_pair(jointData->GetJointNameId(), new JointTransform(*jointData)));
+			m_pose.insert(std::make_pair(jointData->GetJointNameId(), new JointTransform(*jointData)));
 		}
 	}
 
 	Keyframe::~Keyframe()
 	{
-		for (auto transform : *m_pose)
+		for (auto transform : m_pose)
 		{
 			delete transform.second;
 		}
-
-		delete m_pose;
 	}
 }

--- a/Sources/Animations/Keyframe/Keyframe.hpp
+++ b/Sources/Animations/Keyframe/Keyframe.hpp
@@ -18,7 +18,7 @@ namespace fl
 	{
 	private:
 		float m_timeStamp;
-		std::map<std::string, JointTransform *> *m_pose;
+		std::map<std::string, JointTransform *> m_pose;
 	public:
 		/// <summary>
 		/// Creates a new keyframe at a timestamp.
@@ -42,6 +42,6 @@ namespace fl
 		/// indexed by the name of the joint that they correspond to.
 		/// </summary>
 		/// <returns> The desired local-space transforms. </returns>
-		std::map<std::string, JointTransform *> *GetPose() const { return m_pose; }
+		std::map<std::string, JointTransform *> GetPose() const { return m_pose; }
 	};
 }

--- a/Sources/Animations/Keyframe/KeyframeData.cpp
+++ b/Sources/Animations/Keyframe/KeyframeData.cpp
@@ -14,6 +14,6 @@ namespace fl
 
 	void KeyframeData::AddJointTransform(JointTransformData *transform)
 	{
-		m_jointTransforms.push_back(transform);
+		m_jointTransforms.emplace_back(transform);
 	}
 }

--- a/Sources/Animations/MaterialAnimated.cpp
+++ b/Sources/Animations/MaterialAnimated.cpp
@@ -28,16 +28,16 @@ namespace fl
 	{
 	}
 
-	void MaterialAnimated::PushUniforms(UniformHandler *uniformObject)
+	void MaterialAnimated::PushUniforms(UniformHandler &uniformObject)
 	{
 		auto meshAnimated = GetGameObject()->GetComponent<MeshAnimated>();
 		auto joints = meshAnimated->GetJointTransforms();
 
-		uniformObject->Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
-		uniformObject->Push("jointTransforms", *joints.data(), sizeof(Matrix4) * joints.size());
+		uniformObject.Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
+		uniformObject.Push("jointTransforms", *joints.data(), sizeof(Matrix4) * joints.size());
 	}
 
-	void MaterialAnimated::PushDescriptors(DescriptorsHandler *descriptorSet)
+	void MaterialAnimated::PushDescriptors(DescriptorsHandler &descriptorSet)
 	{
 	}
 }

--- a/Sources/Animations/MaterialAnimated.hpp
+++ b/Sources/Animations/MaterialAnimated.hpp
@@ -11,7 +11,7 @@ namespace fl
 		public IMaterial
 	{
 	private:
-		PipelineMaterial *m_material;
+		std::shared_ptr<PipelineMaterial> m_material;
 	public:
 		MaterialAnimated();
 
@@ -29,6 +29,6 @@ namespace fl
 
 		std::string GetName() const override { return "MaterialAnimated"; };
 
-		PipelineMaterial *GetMaterial() const override { return m_material; }
+		std::shared_ptr<PipelineMaterial> GetMaterial() const override { return m_material; }
 	};
 }

--- a/Sources/Animations/MaterialAnimated.hpp
+++ b/Sources/Animations/MaterialAnimated.hpp
@@ -23,9 +23,9 @@ namespace fl
 
 		void Write(LoadedValue *destination) override;
 
-		void PushUniforms(UniformHandler *uniformObject) override;
+		void PushUniforms(UniformHandler &uniformObject) override;
 
-		void PushDescriptors(DescriptorsHandler *descriptorSet) override;
+		void PushDescriptors(DescriptorsHandler &descriptorSet) override;
 
 		std::string GetName() const override { return "MaterialAnimated"; };
 

--- a/Sources/Animations/MeshAnimated.cpp
+++ b/Sources/Animations/MeshAnimated.cpp
@@ -107,7 +107,6 @@ namespace fl
 	{
 		if (headJoint.GetIndex() < jointMatrices->size())
 		{
-		//	jointMatrices->insert(jointMatrices->begin() + headJoint.GetIndex(), *headJoint.GetAnimatedTransform());
 			jointMatrices->at(headJoint.GetIndex()) = *headJoint.GetAnimatedTransform();
 		}
 

--- a/Sources/Animations/MeshAnimated.cpp
+++ b/Sources/Animations/MeshAnimated.cpp
@@ -24,7 +24,6 @@ namespace fl
 	MeshAnimated::~MeshAnimated()
 	{
 		delete m_headJoint;
-		delete m_model;
 		delete m_animation;
 		delete m_animator;
 	}
@@ -58,7 +57,6 @@ namespace fl
 	{
 		delete m_animation;
 		delete m_headJoint;
-		delete m_model;
 		delete m_animator;
 
 		if (!FileSystem::FileExists(filename))
@@ -76,7 +74,7 @@ namespace fl
 		GeometryLoader *geometryLoader = new GeometryLoader(file->GetParent()->GetChild("COLLADA")->GetChild("library_geometries"), skinLoader->GetVerticesSkinData());
 		auto vertices = geometryLoader->GetVertices();
 		auto indices = geometryLoader->GetIndices();
-		m_model = new Model(vertices, indices);
+		m_model = std::make_shared<Model>(vertices, indices, filename);
 		m_headJoint = CreateJoints(skeletonLoader->GetHeadJoint());
 		delete skeletonLoader;
 		delete skinLoader;

--- a/Sources/Animations/MeshAnimated.cpp
+++ b/Sources/Animations/MeshAnimated.cpp
@@ -5,7 +5,7 @@
 
 namespace fl
 {
-	const Matrix4 *MeshAnimated::S_CORRECTION = new Matrix4(Matrix4::IDENTITY.Rotate(Maths::Radians(-90.0f), Vector3::RIGHT));
+	const Matrix4 *MeshAnimated::CORRECTION = new Matrix4(Matrix4::IDENTITY.Rotate(Maths::Radians(-90.0f), Vector3::RIGHT));
 	const int MeshAnimated::MAX_JOINTS = 50;
 	const int MeshAnimated::MAX_WEIGHTS = 3;
 

--- a/Sources/Animations/MeshAnimated.hpp
+++ b/Sources/Animations/MeshAnimated.hpp
@@ -25,7 +25,7 @@ namespace fl
 		Animator *m_animator;
 		std::vector<Matrix4> m_jointMatrices;
 	public:
-		static const Matrix4 *S_CORRECTION;
+		static const Matrix4 *CORRECTION;
 		static const int MAX_JOINTS;
 		static const int MAX_WEIGHTS;
 

--- a/Sources/Animations/MeshAnimated.hpp
+++ b/Sources/Animations/MeshAnimated.hpp
@@ -20,12 +20,12 @@ namespace fl
 
 		std::shared_ptr<Model> m_model;
 		Joint *m_headJoint;
+		Animator *m_animator;
 		Animation *m_animation;
 
-		Animator *m_animator;
 		std::vector<Matrix4> m_jointMatrices;
 	public:
-		static const Matrix4 *CORRECTION;
+		static const Matrix4 CORRECTION;
 		static const int MAX_JOINTS;
 		static const int MAX_WEIGHTS;
 

--- a/Sources/Animations/MeshAnimated.hpp
+++ b/Sources/Animations/MeshAnimated.hpp
@@ -18,7 +18,7 @@ namespace fl
 	private:
 		std::string m_filename;
 
-		Model *m_model;
+		std::shared_ptr<Model> m_model;
 		Joint *m_headJoint;
 		Animation *m_animation;
 
@@ -41,9 +41,9 @@ namespace fl
 
 		std::string GetName() const override { return "MeshAnimated"; };
 
-		Model *GetModel() const override { return m_model; }
+		std::shared_ptr<Model> GetModel() const override { return m_model; }
 
-		void SetModel(Model *model) override { m_model = model; }
+		void SetModel(std::shared_ptr<Model> model) override { m_model = model; }
 
 		void TrySetModel(const std::string &filename) override;
 

--- a/Sources/Animations/Skeleton/SkeletonLoader.cpp
+++ b/Sources/Animations/Skeleton/SkeletonLoader.cpp
@@ -76,15 +76,13 @@ namespace fl
 
 	Matrix4 SkeletonLoader::ConvertData(const std::vector<std::string> &rawData)
 	{
-		float *data = new float[16];
+		Matrix4 result = Matrix4();
 
 		for (unsigned int i = 0; i < rawData.size(); i++)
 		{
-			data[i] = std::stof(rawData[i]);
+			result.m_linear[i] = std::stof(rawData[i]);
 		}
 
-		Matrix4 result = Matrix4(data);
-		delete[] data;
 		return result;
 	}
 }

--- a/Sources/Animations/Skeleton/SkeletonLoader.cpp
+++ b/Sources/Animations/Skeleton/SkeletonLoader.cpp
@@ -54,7 +54,7 @@ namespace fl
 		if (isRoot)
 		{
 			// Because in Blender z is up, but the engine is y up.
-			matrix *= *MeshAnimated::S_CORRECTION;
+			matrix *= *MeshAnimated::CORRECTION;
 		}
 
 		m_jointCount++;

--- a/Sources/Animations/Skeleton/SkeletonLoader.cpp
+++ b/Sources/Animations/Skeleton/SkeletonLoader.cpp
@@ -48,13 +48,12 @@ namespace fl
 		std::string nameId = jointNode->GetChild("-id")->GetString();
 		auto index = GetBoneIndex(nameId);
 		auto matrixData = FormatString::Split(jointNode->GetChild("matrix")->GetChild("#text")->GetString(), " ");
-		Matrix4 matrix = ConvertData(matrixData);
-		matrix = matrix.Transpose();
+		Matrix4 matrix = ConvertData(matrixData).Transpose();
 
 		if (isRoot)
 		{
 			// Because in Blender z is up, but the engine is y up.
-			matrix *= *MeshAnimated::CORRECTION;
+			matrix *= MeshAnimated::CORRECTION;
 		}
 
 		m_jointCount++;

--- a/Sources/Animations/Skin/SkinLoader.cpp
+++ b/Sources/Animations/Skin/SkinLoader.cpp
@@ -78,7 +78,7 @@ namespace fl
 			}
 
 			skinData->LimitJointNumber(m_maxWeights);
-			m_verticesSkinData.push_back(skinData);
+			m_verticesSkinData.emplace_back(skinData);
 		}
 	}
 }

--- a/Sources/Animations/Skin/SkinLoader.cpp
+++ b/Sources/Animations/Skin/SkinLoader.cpp
@@ -38,7 +38,7 @@ namespace fl
 		LoadedValue *weightsNode = m_skinData->GetChildWithAttribute("source", "-id", weightsDataId)->GetChild("float_array");
 
 		auto rawData = FormatString::Split(weightsNode->GetChild("#text")->GetString(), " ");
-		std::vector<float> weights = std::vector<float>(rawData.size());
+		auto weights = std::vector<float>(rawData.size());
 
 		for (int i = 0; i < weights.size(); i++)
 		{
@@ -51,7 +51,7 @@ namespace fl
 	std::vector<int> SkinLoader::GetEffectiveJointsCounts(LoadedValue *weightsDataNode)
 	{
 		auto rawData = FormatString::Split(weightsDataNode->GetChild("vcount")->GetString(), " ");
-		std::vector<int> counts = std::vector<int>(rawData.size());
+		auto counts = std::vector<int>(rawData.size());
 
 		for (int i = 0; i < rawData.size(); i++)
 		{

--- a/Sources/Animations/Skin/VertexSkinData.cpp
+++ b/Sources/Animations/Skin/VertexSkinData.cpp
@@ -24,8 +24,8 @@ namespace fl
 			}
 		}
 
-		m_jointIds.push_back(jointId);
-		m_weights.push_back(weight);
+		m_jointIds.emplace_back(jointId);
+		m_weights.emplace_back(weight);
 	}
 
 	void VertexSkinData::LimitJointNumber(const unsigned int &max)
@@ -47,8 +47,8 @@ namespace fl
 	{
 		while (m_jointIds.size() < max)
 		{
-			m_jointIds.push_back(0);
-			m_weights.push_back(0.0f);
+			m_jointIds.emplace_back(0);
+			m_weights.emplace_back(0.0f);
 		}
 	}
 
@@ -71,7 +71,7 @@ namespace fl
 
 		for (float topWeight : topWeights)
 		{
-			m_weights.push_back(topWeight / total);
+			m_weights.emplace_back(topWeight / total);
 		}
 	}
 

--- a/Sources/Animations/Skin/VertexSkinData.cpp
+++ b/Sources/Animations/Skin/VertexSkinData.cpp
@@ -18,8 +18,8 @@ namespace fl
 		{
 			if (weight > m_weights.at(i))
 			{
-				m_jointIds.insert(m_jointIds.begin() + i, jointId);
-				m_weights.insert(m_weights.begin() + i, weight);
+				m_jointIds[i] = jointId;
+				m_weights[i] = weight;
 				return;
 			}
 		}
@@ -32,8 +32,8 @@ namespace fl
 	{
 		if (m_jointIds.size() > max)
 		{
-			std::vector<float> topWeights = std::vector<float>(max);
-			float total = SaveTopWeights(&topWeights);
+			auto topWeights = std::vector<float>(max);
+			float total = SaveTopWeights(topWeights);
 			RefillWeightList(topWeights, total);
 			RemoveExcessJointIds(max);
 		}
@@ -52,14 +52,14 @@ namespace fl
 		}
 	}
 
-	float VertexSkinData::SaveTopWeights(std::vector<float> *topWeightsArray)
+	float VertexSkinData::SaveTopWeights(std::vector<float> &topWeightsArray)
 	{
 		float total = 0.0f;
 
-		for (unsigned int i = 0; i < topWeightsArray->size(); i++)
+		for (unsigned int i = 0; i < topWeightsArray.size(); i++)
 		{
-			topWeightsArray->at(i) = m_weights.at(i);
-			total += topWeightsArray->at(i);
+			topWeightsArray.at(i) = m_weights.at(i);
+			total += topWeightsArray.at(i);
 		}
 
 		return total;

--- a/Sources/Animations/Skin/VertexSkinData.hpp
+++ b/Sources/Animations/Skin/VertexSkinData.hpp
@@ -21,7 +21,7 @@ namespace fl
 
 		void FillEmptyWeights(const unsigned int &max);
 
-		float SaveTopWeights(std::vector<float> *topWeightsArray);
+		float SaveTopWeights(std::vector<float> &topWeightsArray);
 
 		void RefillWeightList(const std::vector<float> &topWeights, const float &total);
 

--- a/Sources/Audio/Audio.cpp
+++ b/Sources/Audio/Audio.cpp
@@ -35,19 +35,21 @@ namespace fl
 
 	void Audio::Update()
 	{
-		ICamera *camera = Scenes::Get()->GetCamera();
+		auto camera = Scenes::Get()->GetCamera();
 
 		if (camera != nullptr)
 		{
 			// Listener position.
-			alListener3f(AL_POSITION, camera->GetPosition()->m_x, camera->GetPosition()->m_y, camera->GetPosition()->m_z);
+			Vector3 currentPosition = camera->GetPosition();
+			alListener3f(AL_POSITION, currentPosition.m_x, currentPosition.m_y, currentPosition.m_z);
 
 			// Listener velocity.
-			alListener3f(AL_VELOCITY, camera->GetVelocity()->m_x, camera->GetVelocity()->m_y, camera->GetVelocity()->m_z);
+			Vector3 currentVelocity = camera->GetVelocity();
+			alListener3f(AL_VELOCITY, currentVelocity.m_x, currentVelocity.m_y, currentVelocity.m_z);
 
 			// Listener orientation.
-			Vector3 *currentRay = camera->GetViewRay()->m_currentRay;
-			ALfloat orientation[6] = {currentRay->m_x, currentRay->m_y, currentRay->m_z, 0.0f, 1.0f, 0.0f};
+			Vector3 currentRay = camera->GetViewRay().GetCurrentRay();
+			ALfloat orientation[6] = {currentRay.m_x, currentRay.m_y, currentRay.m_z, 0.0f, 1.0f, 0.0f};
 
 			alListenerfv(AL_ORIENTATION, orientation);
 			ErrorAl(alGetError());

--- a/Sources/Audio/Sound.cpp
+++ b/Sources/Audio/Sound.cpp
@@ -17,7 +17,7 @@ namespace fl
 		m_gain(gain),
 		m_pitch(pitch)
 	{
-		SoundBuffer *soundBuffer = SoundBuffer::Resource(filename);
+		auto soundBuffer = SoundBuffer::Resource(filename);
 
 		alGenSources(1, &m_source);
 		alSourcei(m_source, AL_BUFFER, soundBuffer->GetBuffer());

--- a/Sources/Audio/SoundBuffer.hpp
+++ b/Sources/Audio/SoundBuffer.hpp
@@ -18,17 +18,17 @@ namespace fl
 		std::string m_filename;
 		unsigned int m_buffer;
 	public:
-		static SoundBuffer *Resource(const std::string &filename)
+		static std::shared_ptr<SoundBuffer> Resource(const std::string &filename)
 		{
-			IResource *resource = Resources::Get()->Get(filename);
+			auto resource = Resources::Get()->Get(filename);
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<SoundBuffer *>(resource);
+				return std::dynamic_pointer_cast<SoundBuffer>(resource);
 			}
 
-			SoundBuffer *result = new SoundBuffer(filename);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<SoundBuffer>(filename);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 

--- a/Sources/Display/Display.cpp
+++ b/Sources/Display/Display.cpp
@@ -205,18 +205,16 @@ namespace fl
 
 			if (data == nullptr)
 			{
-				printf("Unable to load texture: '%s'\n", m_icon.c_str());
-			}
-			else
-			{
-				GLFWimage icons[1];
-				icons[0].pixels = data;
-				icons[0].width = width;
-				icons[0].height = height;
-
-				glfwSetWindowIcon(m_window, 1, icons);
+				fprintf(stderr, "Unable to load texture: '%s'\n", m_icon.c_str());
+				return;
 			}
 
+			GLFWimage icons[1];
+			icons[0].pixels = data;
+			icons[0].width = width;
+			icons[0].height = height;
+
+			glfwSetWindowIcon(m_window, 1, icons);
 			Texture::DeletePixels(data);
 		}
 	}

--- a/Sources/Display/Display.cpp
+++ b/Sources/Display/Display.cpp
@@ -490,13 +490,13 @@ namespace fl
 					fprintf(stderr, "Vulkan validation layer not found: '%s'\n", layerName);
 				}
 
-				m_instanceLayerList.push_back(layerName);
+				m_instanceLayerList.emplace_back(layerName);
 			}
 		}
 
 		for (auto layerName : DEVICE_EXTENSIONS)
 		{
-			m_deviceExtensionList.push_back(layerName);
+			m_deviceExtensionList.emplace_back(layerName);
 		}
 	}
 
@@ -508,12 +508,12 @@ namespace fl
 
 		for (uint32_t i = 0; i < glfwExtensionCount; i++)
 		{
-			m_instanceExtensionList.push_back(glfwExtensions[i]);
+			m_instanceExtensionList.emplace_back(glfwExtensions[i]);
 		}
 
 		if (m_validationLayers)
 		{
-			m_instanceExtensionList.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+			m_instanceExtensionList.emplace_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 		}
 	}
 
@@ -604,7 +604,7 @@ namespace fl
 			VkPhysicalDeviceProperties deviceProperties;
 			vkGetPhysicalDeviceProperties(device, &deviceProperties);
 			int score = ScorePhysicalDevice(device);
-			rankedDevices.insert(std::make_pair(score, device));
+			rankedDevices.emplace(score, device);
 		}
 
 		// Checks to make sure the best candidate scored higher than 0  rbegin points to last element of ranked devices(highest rated), first is its rating.

--- a/Sources/Engine/Engine.cpp
+++ b/Sources/Engine/Engine.cpp
@@ -4,7 +4,7 @@
 
 namespace fl
 {
-	Engine *Engine::G_INSTANCE = nullptr;
+	Engine *Engine::INSTANCE = nullptr;
 
 	Engine::Engine(const bool &emptyRegister) :
 		m_start(HighResolutionClock::now()),
@@ -15,7 +15,7 @@ namespace fl
 		m_running(true),
 		m_error(false)
 	{
-		G_INSTANCE = this;
+		INSTANCE = this;
 
 		m_moduleRegister = static_cast<ModuleRegister *>(malloc(sizeof(ModuleRegister)));
 		new(m_moduleRegister) ModuleRegister(emptyRegister);

--- a/Sources/Engine/Engine.hpp
+++ b/Sources/Engine/Engine.hpp
@@ -20,7 +20,7 @@ namespace fl
 		typedef std::chrono::high_resolution_clock HighResolutionClock;
 		typedef std::chrono::duration<float, std::milli> MillisecondsType;
 
-		static Engine *G_INSTANCE;
+		static Engine *INSTANCE;
 
 		std::chrono::time_point<HighResolutionClock> m_start;
 		float m_timeOffset;
@@ -40,7 +40,7 @@ namespace fl
 		/// <returns> The current engine instance. </returns>
 		static Engine *Get()
 		{
-			return G_INSTANCE;
+			return INSTANCE;
 		}
 
 		/// <summary>

--- a/Sources/Engine/Engine.hpp
+++ b/Sources/Engine/Engine.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <array>
 #include "ModuleRegister.hpp"
 #include "IUpdater.hpp"
 

--- a/Sources/Engine/ModuleRegister.cpp
+++ b/Sources/Engine/ModuleRegister.cpp
@@ -16,7 +16,7 @@
 namespace fl
 {
 	ModuleRegister::ModuleRegister(const bool &emptyRegister) :
-		m_modules(new std::multimap<float, ModulePair>())
+		m_modules(std::map<float, ModulePair>())
 	{
 		if (!emptyRegister)
 		{
@@ -39,30 +39,28 @@ namespace fl
 
 	ModuleRegister::~ModuleRegister()
 	{
-		for (auto it = --m_modules->end(); it != m_modules->begin(); --it)
+		for (auto it = --m_modules.end(); it != m_modules.begin(); --it)
 		{
 			delete (*it).second.second;
 		}
-
-		delete m_modules;
 	}
 
 	IModule *ModuleRegister::RegisterModule(IModule *module, const ModuleUpdate &update, const std::string &name)
 	{
-		//	if (m_modules->find(name) != m_modules->end())
+		//	if (m_modules.find(name) != m_modules.end())
 		//	{
 		//		fprintf(stderr, "Module '%s' is already registered!\n", name.c_str());
 		//		return;
 		//	}
 
-		float offset = update + (0.01f * static_cast<float>(m_modules->size()));
-		m_modules->insert(std::make_pair(offset, std::make_pair(name, module)));
+		float offset = update + (0.01f * static_cast<float>(m_modules.size()));
+		m_modules.insert(std::make_pair(offset, std::make_pair(name, module)));
 		return module;
 	}
 
 	IModule *ModuleRegister::GetModule(const std::string &name)
 	{
-		for (auto &module : *m_modules)
+		for (auto module : m_modules)
 		{
 			if (module.second.first == name)
 			{
@@ -75,16 +73,16 @@ namespace fl
 
 	void ModuleRegister::DeregisterModule(const std::string &name)
 	{
-		for (auto it = --m_modules->end(); it != m_modules->begin(); --it)
+		for (auto it = --m_modules.end(); it != m_modules.begin(); --it)
 		{
-			m_modules->erase(it);
+			m_modules.erase(it);
 			delete (*it).second.second;
 		}
 	}
 
 	void ModuleRegister::RunUpdate(const ModuleUpdate &update) const
 	{
-		for (auto &module : *m_modules)
+		for (auto module : m_modules)
 		{
 			if (static_cast<int>(std::floor(module.first)) == update)
 			{

--- a/Sources/Engine/ModuleRegister.cpp
+++ b/Sources/Engine/ModuleRegister.cpp
@@ -54,7 +54,7 @@ namespace fl
 		//	}
 
 		float offset = update + (0.01f * static_cast<float>(m_modules.size()));
-		m_modules.insert(std::make_pair(offset, std::make_pair(name, module)));
+		m_modules.emplace(offset, std::make_pair(name, module));
 		return module;
 	}
 

--- a/Sources/Engine/ModuleRegister.hpp
+++ b/Sources/Engine/ModuleRegister.hpp
@@ -14,7 +14,7 @@ namespace fl
 	private:
 		typedef std::pair<std::string, IModule *> ModulePair;
 
-		std::multimap<float, ModulePair> *m_modules;
+		std::map<float, ModulePair> m_modules;
 	public:
 		/// <summary>
 		/// Creates a new module register.

--- a/Sources/Events/EventTime.cpp
+++ b/Sources/Events/EventTime.cpp
@@ -4,7 +4,7 @@ namespace fl
 {
 	EventTime::EventTime(const float &interval, const bool &repeat, const std::function<void()> &onEvent) :
 		IEvent(),
-		m_timer(new Timer(interval)),
+		m_timer(Timer(interval)),
 		m_repeat(repeat),
 		m_onEvent(onEvent)
 	{
@@ -12,14 +12,13 @@ namespace fl
 
 	EventTime::~EventTime()
 	{
-		delete m_timer;
 	}
 
 	bool EventTime::EventTriggered()
 	{
-		if (m_timer->IsPassedTime())
+		if (m_timer.IsPassedTime())
 		{
-			m_timer->ResetStartTime();
+			m_timer.ResetStartTime();
 			return true;
 		}
 

--- a/Sources/Events/EventTime.hpp
+++ b/Sources/Events/EventTime.hpp
@@ -13,7 +13,7 @@ namespace fl
 		public IEvent
 	{
 	private:
-		Timer *m_timer;
+		Timer m_timer;
 		bool m_repeat;
 		std::function<void()> m_onEvent;
 	public:

--- a/Sources/Events/Events.cpp
+++ b/Sources/Events/Events.cpp
@@ -4,23 +4,21 @@ namespace fl
 {
 	Events::Events() :
 		IModule(),
-		m_events(new std::vector<IEvent *>())
+		m_events(std::vector<IEvent *>())
 	{
 	}
 
 	Events::~Events()
 	{
-		for (auto event : *m_events)
+		for (auto event : m_events)
 		{
 			delete event;
 		}
-
-		delete m_events;
 	}
 
 	void Events::Update()
 	{
-		std::vector<IEvent *> copy = std::vector<IEvent *>(*m_events);
+		std::vector<IEvent *> copy = std::vector<IEvent *>(m_events); // TODO: Remove copying.
 
 		for (auto event : copy)
 		{
@@ -36,18 +34,18 @@ namespace fl
 		}
 	}
 
-	void Events::AddEvent(IEvent *event) const
+	void Events::AddEvent(IEvent *event)
 	{
-		m_events->push_back(event);
+		m_events.push_back(event);
 	}
 
-	void Events::RemoveEvent(IEvent *event) const
+	void Events::RemoveEvent(IEvent *event)
 	{
-		for (auto it = m_events->begin(); it != m_events->end(); ++it)
+		for (auto it = m_events.begin(); it != m_events.end(); ++it)
 		{
 			if (*it == event)
 			{
-				m_events->erase(it);
+				m_events.erase(it);
 				return;
 			}
 		}

--- a/Sources/Events/Events.cpp
+++ b/Sources/Events/Events.cpp
@@ -18,18 +18,18 @@ namespace fl
 
 	void Events::Update()
 	{
-		std::vector<IEvent *> copy = std::vector<IEvent *>(m_events); // TODO: Remove copying.
-
-		for (auto event : copy)
+		for (auto event : std::vector<IEvent *>(m_events)) // TODO: Remove copying.
 		{
-			if (event->EventTriggered())
+			if (!event->EventTriggered())
 			{
-				event->OnEvent();
+				continue;
+			}
 
-				if (event->RemoveAfterEvent())
-				{
-					RemoveEvent(event);
-				}
+			event->OnEvent();
+
+			if (event->RemoveAfterEvent())
+			{
+				RemoveEvent(event);
 			}
 		}
 	}

--- a/Sources/Events/Events.cpp
+++ b/Sources/Events/Events.cpp
@@ -36,7 +36,7 @@ namespace fl
 
 	void Events::AddEvent(IEvent *event)
 	{
-		m_events.push_back(event);
+		m_events.emplace_back(event);
 	}
 
 	void Events::RemoveEvent(IEvent *event)

--- a/Sources/Events/Events.hpp
+++ b/Sources/Events/Events.hpp
@@ -13,7 +13,7 @@ namespace fl
 		public IModule
 	{
 	private:
-		std::vector<IEvent *> *m_events;
+		std::vector<IEvent *> m_events;
 	public:
 		/// <summary>
 		/// Gets this engine instance.
@@ -40,12 +40,12 @@ namespace fl
 		/// Adds an event to the listening list.
 		/// </summary>
 		/// <param name="event"> The event to add. </param>
-		void AddEvent(IEvent *event) const;
+		void AddEvent(IEvent *event);
 
 		/// <summary>
 		/// Removes a event to the listening list.
 		/// </summary>
 		/// <param name="event"> The event to remove. </param>
-		void RemoveEvent(IEvent *event) const;
+		void RemoveEvent(IEvent *event);
 	};
 }

--- a/Sources/Files/Config.cpp
+++ b/Sources/Files/Config.cpp
@@ -31,7 +31,7 @@ namespace fl
 
 		for (auto fm : fileMap)
 		{
-			m_values->insert(std::make_pair(fm.first, new ConfigKey(fm.second, true)));
+			m_values->emplace(fm.first, new ConfigKey(fm.second, true));
 		}
 	}
 
@@ -61,7 +61,7 @@ namespace fl
 		if (m_values->find(key) == m_values->end())
 		{
 			auto configKey = new ConfigKey(normal, false);
-			m_values->insert(std::make_pair(key, configKey));
+			m_values->emplace(key, configKey);
 			return configKey;
 		}
 
@@ -72,7 +72,7 @@ namespace fl
 	{
 		if (m_values->find(key) == m_values->end())
 		{
-			m_values->insert(std::make_pair(key, new ConfigKey(value, false)));
+			m_values->emplace(key, new ConfigKey(value, false));
 			return;
 		}
 

--- a/Sources/Files/Csv/FileCsv.cpp
+++ b/Sources/Files/Csv/FileCsv.cpp
@@ -22,7 +22,7 @@ namespace fl
 	void FileCsv::Load()
 	{
 #if FL_VERBOSE
-		const auto debugStart = Engine::Get()->GetTimeMs();
+		float debugStart = Engine::Get()->GetTimeMs();
 #endif
 
 		if (!FileSystem::FileExists(m_filename))
@@ -32,16 +32,16 @@ namespace fl
 		}
 
 		std::string fileLoaded = FileSystem::ReadTextFile(m_filename);
-		std::vector<std::string> lines = FormatString::Split(fileLoaded, "\n", true);
+		auto lines = FormatString::Split(fileLoaded, "\n", true);
 
 		for (auto &line : lines)
 		{
 			RowCsv row = RowCsv(FormatString::Split(line, std::string(1, m_delimiter), true));
-			m_rows->push_back(row);
+			m_rows->emplace_back(row);
 		}
 
 #if FL_VERBOSE
-		const auto debugEnd = Engine::Get()->GetTimeMs();
+		float debugEnd = Engine::Get()->GetTimeMs();
 		printf("Json '%s' loaded in %fms\n", m_filename.c_str(), debugEnd - debugStart);
 #endif
 	}
@@ -78,7 +78,7 @@ namespace fl
 		for (unsigned int i = 0; i < m_rows->size(); i++)
 		{
 			RowCsv row = m_rows->at(i);
-			result.insert(std::make_pair(row.GetElements().at(0), row.GetElements().at(1)));
+			result.emplace(row.GetElements().at(0), row.GetElements().at(1));
 		}
 
 		return result;
@@ -86,7 +86,7 @@ namespace fl
 
 	void FileCsv::ConfigPushValue(const std::string &key, const std::string &value)
 	{
-		m_rows->push_back(RowCsv({key, value}));
+		m_rows->emplace_back(RowCsv({key, value}));
 	}
 
 	RowCsv FileCsv::GetRow(const unsigned int &index)
@@ -96,7 +96,7 @@ namespace fl
 
 	void FileCsv::PushRow(const RowCsv &row)
 	{
-		m_rows->push_back(row);
+		m_rows->emplace_back(row);
 	}
 
 	void FileCsv::SetRow(const RowCsv &row, const unsigned int &index)
@@ -105,7 +105,7 @@ namespace fl
 		{
 			for (size_t i = m_rows->size(); i <= index; i++)
 			{
-				m_rows->push_back(RowCsv({}));
+				m_rows->emplace_back(RowCsv({}));
 			}
 		}
 

--- a/Sources/Files/Json/FileJson.cpp
+++ b/Sources/Files/Json/FileJson.cpp
@@ -20,7 +20,7 @@ namespace fl
 	void FileJson::Load()
 	{
 #if FL_VERBOSE
-		const auto debugStart = Engine::Get()->GetTimeMs();
+		float debugStart = Engine::Get()->GetTimeMs();
 #endif
 
 		if (!FileSystem::FileExists(m_filename))
@@ -92,7 +92,7 @@ namespace fl
 		delete currentSection;
 
 #if FL_VERBOSE
-		const auto debugEnd = Engine::Get()->GetTimeMs();
+		float debugEnd = Engine::Get()->GetTimeMs();
 		printf("Json '%s' loaded in %fms\n", m_filename.c_str(), debugEnd - debugStart);
 #endif
 	}
@@ -128,7 +128,7 @@ namespace fl
 				continue;
 			}
 
-			result.insert(std::make_pair(child->GetName(), child->GetValue()));
+			result.emplace(child->GetName(), child->GetValue());
 		}
 
 		return result;
@@ -145,7 +145,7 @@ namespace fl
 		}
 
 		LoadedValue *newChild = new LoadedValue(m_parent, key, value);
-		m_parent->GetChildren()->push_back(newChild);
+		m_parent->GetChildren()->emplace_back(newChild);
 	}
 
 	void FileJson::Verify()

--- a/Sources/Files/Json/JsonSection.cpp
+++ b/Sources/Files/Json/JsonSection.cpp
@@ -86,7 +86,7 @@ namespace fl
 		if (!isTopSection)
 		{
 			thisValue = new LoadedValue(parent, source->m_name, "");
-			parent->GetChildren()->push_back(thisValue);
+			parent->GetChildren()->emplace_back(thisValue);
 
 			auto contentSplit = FormatString::Split(source->m_content, ",", true);
 
@@ -100,7 +100,7 @@ namespace fl
 				}
 
 				LoadedValue *newChild = new LoadedValue(thisValue, dataSplit.at(0), dataSplit.at(1));
-				thisValue->GetChildren()->push_back(newChild);
+				thisValue->GetChildren()->emplace_back(newChild);
 			}
 		}
 

--- a/Sources/Files/Json/JsonSection.hpp
+++ b/Sources/Files/Json/JsonSection.hpp
@@ -25,7 +25,7 @@ namespace fl
 
 		std::vector<JsonSection *> GetChildren() const { return m_children; }
 
-		void AddChild(JsonSection *child) { m_children.push_back(child); }
+		void AddChild(JsonSection *child) { m_children.emplace_back(child); }
 
 		std::string GetName() const { return m_name; }
 

--- a/Sources/Files/LoadedValue.cpp
+++ b/Sources/Files/LoadedValue.cpp
@@ -38,7 +38,7 @@ namespace fl
 		}
 
 		LoadedValue *child = new LoadedValue(this, name, "");
-		m_children->push_back(child);
+		m_children->emplace_back(child);
 		return child;
 	}
 

--- a/Sources/Files/LoadedValue.hpp
+++ b/Sources/Files/LoadedValue.hpp
@@ -48,7 +48,7 @@ namespace fl
 			}
 
 			child = value;
-			m_children->push_back(child);
+			m_children->emplace_back(child);
 		}
 
 		template<typename T>
@@ -60,7 +60,7 @@ namespace fl
 			if (child == nullptr)
 			{
 				child = new LoadedValue(this, name, strValue);
-				m_children->push_back(child);
+				m_children->emplace_back(child);
 				return;
 			}
 

--- a/Sources/Fonts/FontFamily.cpp
+++ b/Sources/Fonts/FontFamily.cpp
@@ -17,23 +17,18 @@ namespace fl
 
 	FontFamily::~FontFamily()
 	{
-		delete m_typeThin;
-		delete m_typeLight;
-		delete m_typeRegular;
-		delete m_typeSemibold;
-		delete m_typeBold;
 	}
 
-	FontType *FontFamily::LoadFontType(const std::string &filename, const std::string &suffex)
+	std::shared_ptr<FontType> FontFamily::LoadFontType(const std::string &filename, const std::string &suffex)
 	{
-		const std::string filepathPng = filename + "/" + suffex + ".png";
-		const std::string filepathFnt = filename + "/" + suffex + ".fnt";
+		std::string filepathPng = filename + "/" + suffex + ".png";
+		std::string filepathFnt = filename + "/" + suffex + ".fnt";
 
 		if (!FileSystem::FileExists(filepathPng) || !FileSystem::FileExists(filepathFnt))
 		{
 			return nullptr;
 		}
 
-		return new FontType(filepathPng, filepathFnt);
+		return std::make_shared<FontType>(filepathPng, filepathFnt);
 	}
 }

--- a/Sources/Fonts/FontFamily.hpp
+++ b/Sources/Fonts/FontFamily.hpp
@@ -12,11 +12,11 @@ namespace fl
 	private:
 		std::string m_filename;
 
-		FontType *m_typeThin;
-		FontType *m_typeLight;
-		FontType *m_typeRegular;
-		FontType *m_typeSemibold;
-		FontType *m_typeBold;
+		std::shared_ptr<FontType> m_typeThin;
+		std::shared_ptr<FontType> m_typeLight;
+		std::shared_ptr<FontType> m_typeRegular;
+		std::shared_ptr<FontType> m_typeSemibold;
+		std::shared_ptr<FontType> m_typeBold;
 	public:
 		static std::shared_ptr<FontFamily> Resource(const std::string &filename)
 		{
@@ -38,16 +38,16 @@ namespace fl
 
 		std::string GetFilename() override { return m_filename; }
 
-		FontType *GetThin() const { return m_typeThin; }
+		std::shared_ptr<FontType> GetThin() const { return m_typeThin; }
 
-		FontType *GetLight() const { return m_typeLight; }
+		std::shared_ptr<FontType> GetLight() const { return m_typeLight; }
 
-		FontType *GetRegular() const { return m_typeRegular; }
+		std::shared_ptr<FontType> GetRegular() const { return m_typeRegular; }
 
-		FontType *GetSemibold() const { return m_typeSemibold; }
+		std::shared_ptr<FontType> GetSemibold() const { return m_typeSemibold; }
 
-		FontType *GetBold() const { return m_typeBold; }
+		std::shared_ptr<FontType> GetBold() const { return m_typeBold; }
 	private:
-		static FontType *LoadFontType(const std::string &filename, const std::string &suffex);
+		static std::shared_ptr<FontType> LoadFontType(const std::string &filename, const std::string &suffex);
 	};
 }

--- a/Sources/Fonts/FontFamily.hpp
+++ b/Sources/Fonts/FontFamily.hpp
@@ -18,17 +18,17 @@ namespace fl
 		FontType *m_typeSemibold;
 		FontType *m_typeBold;
 	public:
-		static FontFamily *Resource(const std::string &filename)
+		static std::shared_ptr<FontFamily> Resource(const std::string &filename)
 		{
-			IResource *resource = Resources::Get()->Get(filename);
+			auto resource = Resources::Get()->Get(filename);
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<FontFamily *>(resource);
+				return std::dynamic_pointer_cast<FontFamily>(resource);
 			}
 
-			FontFamily *result = new FontFamily(filename);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<FontFamily>(filename);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 

--- a/Sources/Fonts/FontLine.cpp
+++ b/Sources/Fonts/FontLine.cpp
@@ -5,7 +5,7 @@ namespace fl
 	FontLine::FontLine(const double &spaceWidth, const double &maxLength) :
 		m_maxLength(maxLength),
 		m_spaceSize(spaceWidth),
-		m_words(std::vector<FontWord *>()),
+		m_words(std::vector<FontWord>()),
 		m_currentWordsLength(0.0),
 		m_currentLineLength(0.0)
 	{
@@ -13,21 +13,17 @@ namespace fl
 
 	FontLine::~FontLine()
 	{
-		for (auto word : m_words)
-		{
-			delete word;
-		}
 	}
 
-	bool FontLine::AddWord(FontWord *word)
+	bool FontLine::AddWord(const FontWord &word)
 	{
-		double additionalLength = word->GetWidth();
+		double additionalLength = word.GetWidth();
 		additionalLength += !m_words.empty() ? m_spaceSize : 0.0;
 
 		if (m_currentLineLength + additionalLength <= m_maxLength)
 		{
 			m_words.push_back(word);
-			m_currentWordsLength += word->GetWidth();
+			m_currentWordsLength += word.GetWidth();
 			m_currentLineLength += additionalLength;
 			return true;
 		}

--- a/Sources/Fonts/FontLine.cpp
+++ b/Sources/Fonts/FontLine.cpp
@@ -22,7 +22,7 @@ namespace fl
 
 		if (m_currentLineLength + additionalLength <= m_maxLength)
 		{
-			m_words.push_back(word);
+			m_words.emplace_back(word);
 			m_currentWordsLength += word.GetWidth();
 			m_currentLineLength += additionalLength;
 			return true;

--- a/Sources/Fonts/FontLine.hpp
+++ b/Sources/Fonts/FontLine.hpp
@@ -13,7 +13,7 @@ namespace fl
 		double m_maxLength;
 		double m_spaceSize;
 
-		std::vector<FontWord *> m_words;
+		std::vector<FontWord> m_words;
 		double m_currentWordsLength;
 		double m_currentLineLength;
 	public:
@@ -34,13 +34,13 @@ namespace fl
 		/// </summary>
 		/// <param name="word"> The word to try to add. </param>
 		/// <returns> {@code true} if the word has successfully been added to the line. </returns>
-		bool AddWord(FontWord *word);
+		bool AddWord(const FontWord &word);
 
 		double GetMaxLength() const { return m_maxLength; }
 
 		double GetSpaceSize() const { return m_spaceSize; }
 
-		std::vector<FontWord *> GetWords() const { return m_words; }
+		std::vector<FontWord> GetWords() const { return m_words; }
 
 		double GetCurrentWordsLength() const { return m_currentWordsLength; }
 

--- a/Sources/Fonts/FontMetafile.cpp
+++ b/Sources/Fonts/FontMetafile.cpp
@@ -60,15 +60,15 @@ namespace fl
 	void FontMetafile::ProcessNextLine(const std::string &line)
 	{
 		m_values.clear();
-		std::vector<std::string> parts = FormatString::Split(line, SPLITTER);
+		auto parts = FormatString::Split(line, SPLITTER);
 
 		for (auto part : parts)
 		{
-			std::vector<std::string> pairs = FormatString::Split(part, "=");
+			auto pairs = FormatString::Split(part, "=");
 
 			if (pairs.size() == 2)
 			{
-				m_values.insert(std::pair<std::string, std::string>(pairs.at(0), pairs.at(1)));
+				m_values.emplace(pairs.at(0), pairs.at(1));
 			}
 		}
 	}
@@ -77,7 +77,7 @@ namespace fl
 	{
 		for (auto padding : GetValuesOfVariable("padding"))
 		{
-			m_padding.push_back(padding);
+			m_padding.emplace_back(padding);
 		}
 
 		m_paddingWidth = m_padding.at(PAD_LEFT) + m_padding.at(PAD_RIGHT);
@@ -120,7 +120,7 @@ namespace fl
 		}
 
 		FontCharacter character = FontCharacter(id, xTextureCoord, yTextureCoord, xTexSize, yTexSize, xOffset, yOffset, quadWidth, quadHeight, xAdvance);
-		m_metadata.insert(std::pair<int, FontCharacter>(character.GetId(), character));
+		m_metadata.emplace(character.GetId(), character);
 	}
 
 	int FontMetafile::GetValueOfVariable(const std::string &variable)
@@ -137,7 +137,7 @@ namespace fl
 
 		for (auto number : numbers)
 		{
-			result.push_back(std::stoi(number));
+			result.emplace_back(std::stoi(number));
 			i++;
 		}
 

--- a/Sources/Fonts/FontMetafile.cpp
+++ b/Sources/Fonts/FontMetafile.cpp
@@ -19,20 +19,20 @@ namespace fl
 
 	FontMetafile::FontMetafile(const std::string &filename) :
 		IResource(),
-		m_metadata(new std::map<int, FontCharacter *>()),
-		m_values(new std::map<std::string, std::string>()),
+		m_metadata(std::map<int, FontCharacter>()),
+		m_values(std::map<std::string, std::string>()),
 		m_filename(filename),
 		m_verticalPerPixelSize(0.0),
 		m_horizontalPerPixelSize(0.0),
 		m_imageWidth(0),
 		m_spaceWidth(0.0),
-		m_padding(new std::vector<int>()),
+		m_padding(std::vector<int>()),
 		m_paddingWidth(0),
 		m_paddingHeight(0),
 		m_maxSizeY(0.0)
 	{
 		std::string fileLoaded = FileSystem::ReadTextFile(filename);
-		std::vector<std::string> lines = FormatString::Split(fileLoaded, "\n");
+		auto lines = FormatString::Split(fileLoaded, "\n");
 
 		for (auto line : lines)
 		{
@@ -55,15 +55,11 @@ namespace fl
 
 	FontMetafile::~FontMetafile()
 	{
-		delete m_metadata;
-		delete m_values;
-
-		delete m_padding;
 	}
 
 	void FontMetafile::ProcessNextLine(const std::string &line)
 	{
-		m_values->clear();
+		m_values.clear();
 		std::vector<std::string> parts = FormatString::Split(line, SPLITTER);
 
 		for (auto part : parts)
@@ -72,7 +68,7 @@ namespace fl
 
 			if (pairs.size() == 2)
 			{
-				m_values->insert(std::pair<std::string, std::string>(pairs.at(0), pairs.at(1)));
+				m_values.insert(std::pair<std::string, std::string>(pairs.at(0), pairs.at(1)));
 			}
 		}
 	}
@@ -81,11 +77,11 @@ namespace fl
 	{
 		for (auto padding : GetValuesOfVariable("padding"))
 		{
-			m_padding->push_back(padding);
+			m_padding.push_back(padding);
 		}
 
-		m_paddingWidth = m_padding->at(PAD_LEFT) + m_padding->at(PAD_RIGHT);
-		m_paddingHeight = m_padding->at(PAD_TOP) + m_padding->at(PAD_BOTTOM);
+		m_paddingWidth = m_padding.at(PAD_LEFT) + m_padding.at(PAD_RIGHT);
+		m_paddingHeight = m_padding.at(PAD_TOP) + m_padding.at(PAD_BOTTOM);
 	}
 
 	void FontMetafile::LoadLineSizes()
@@ -98,34 +94,24 @@ namespace fl
 
 	void FontMetafile::LoadCharacterData()
 	{
-		FontCharacter *c = LoadCharacter();
-
-		if (c != nullptr)
-		{
-			m_metadata->insert(std::pair<int, FontCharacter *>(c->GetId(), c));
-		}
-	}
-
-	FontCharacter *FontMetafile::LoadCharacter()
-	{
 		int id = GetValueOfVariable("id");
 
 		if (id == SPACE_ASCII)
 		{
 			m_spaceWidth = (GetValueOfVariable("xadvance") - m_paddingWidth) * m_horizontalPerPixelSize;
-			return nullptr;
+			return;
 		}
 
-		double xTextureCoord = (static_cast<double>(GetValueOfVariable("x")) + (m_padding->at(PAD_LEFT) - DESIRED_PADDING)) / m_imageWidth;
-		double yTextureCoord = (static_cast<double>(GetValueOfVariable("y")) + (m_padding->at(PAD_TOP) - DESIRED_PADDING)) / m_imageWidth;
+		double xTextureCoord = (static_cast<double>(GetValueOfVariable("x")) + (m_padding.at(PAD_LEFT) - DESIRED_PADDING)) / m_imageWidth;
+		double yTextureCoord = (static_cast<double>(GetValueOfVariable("y")) + (m_padding.at(PAD_TOP) - DESIRED_PADDING)) / m_imageWidth;
 		int width = GetValueOfVariable("width") - (m_paddingWidth - (2 * DESIRED_PADDING));
 		int height = GetValueOfVariable("height") - ((m_paddingHeight) - (2 * DESIRED_PADDING));
 		double quadWidth = width * m_horizontalPerPixelSize;
 		double quadHeight = height * m_verticalPerPixelSize;
 		double xTexSize = static_cast<double>(width) / m_imageWidth;
 		double yTexSize = static_cast<double>(height) / m_imageWidth;
-		double xOffset = (GetValueOfVariable("xoffset") + m_padding->at(PAD_LEFT) - DESIRED_PADDING) * m_horizontalPerPixelSize;
-		double yOffset = (GetValueOfVariable("yoffset") + (m_padding->at(PAD_TOP) - DESIRED_PADDING)) * m_verticalPerPixelSize;
+		double xOffset = (GetValueOfVariable("xoffset") + m_padding.at(PAD_LEFT) - DESIRED_PADDING) * m_horizontalPerPixelSize;
+		double yOffset = (GetValueOfVariable("yoffset") + (m_padding.at(PAD_TOP) - DESIRED_PADDING)) * m_verticalPerPixelSize;
 		double xAdvance = (GetValueOfVariable("xadvance") - m_paddingWidth) * m_horizontalPerPixelSize;
 
 		if (quadHeight > m_maxSizeY)
@@ -133,18 +119,19 @@ namespace fl
 			m_maxSizeY = quadHeight;
 		}
 
-		return new FontCharacter(id, xTextureCoord, yTextureCoord, xTexSize, yTexSize, xOffset, yOffset, quadWidth, quadHeight, xAdvance);
+		FontCharacter character = FontCharacter(id, xTextureCoord, yTextureCoord, xTexSize, yTexSize, xOffset, yOffset, quadWidth, quadHeight, xAdvance);
+		m_metadata.insert(std::pair<int, FontCharacter>(character.GetId(), character));
 	}
 
 	int FontMetafile::GetValueOfVariable(const std::string &variable)
 	{
-		return std::stoi(m_values->at(variable).c_str());
+		return std::stoi(m_values.at(variable).c_str());
 	}
 
 	std::vector<int> FontMetafile::GetValuesOfVariable(const std::string &variable)
 	{
-		std::vector<std::string> numbers = FormatString::Split(m_values->at(variable), NUMBER_SEPARATOR);
-		std::vector<int> result = std::vector<int>();
+		auto numbers = FormatString::Split(m_values.at(variable), NUMBER_SEPARATOR);
+		auto result = std::vector<int>();
 
 		int i = 0;
 
@@ -157,15 +144,15 @@ namespace fl
 		return result;
 	}
 
-	FontCharacter *FontMetafile::GetCharacter(const int &ascii)
+	FontCharacter FontMetafile::GetCharacter(const int &ascii)
 	{
-		auto it = m_metadata->find(ascii);
+		auto it = m_metadata.find(ascii);
 
-		if (it != m_metadata->end())
+		if (it != m_metadata.end())
 		{
 			return it->second;
 		}
 
-		return nullptr;
+		return FontCharacter(-1, 0, 0, 0, 0, 0, 0, 0, 0, 0); // TODO: Use `std::optional`.
 	}
 }

--- a/Sources/Fonts/FontMetafile.hpp
+++ b/Sources/Fonts/FontMetafile.hpp
@@ -15,15 +15,15 @@ namespace fl
 		public IResource
 	{
 	private:
-		std::map<int, FontCharacter *> *m_metadata;
-		std::map<std::string, std::string> *m_values;
+		std::map<int, FontCharacter> m_metadata;
+		std::map<std::string, std::string> m_values;
 
 		std::string m_filename;
 		double m_verticalPerPixelSize;
 		double m_horizontalPerPixelSize;
 		int m_imageWidth;
 		double m_spaceWidth;
-		std::vector<int> *m_padding;
+		std::vector<int> m_padding;
 		int m_paddingWidth;
 		int m_paddingHeight;
 		double m_maxSizeY;
@@ -65,7 +65,7 @@ namespace fl
 		/// </summary>
 		~FontMetafile();
 
-		FontCharacter *GetCharacter(const int &ascii);
+		FontCharacter GetCharacter(const int &ascii);
 
 		std::string GetFilename() override { return m_filename; }
 
@@ -91,17 +91,10 @@ namespace fl
 		void LoadLineSizes();
 
 		/// <summary>
-		/// Loads in data about each character and stores the data in the <seealso cref="Character"/> class.
-		/// </summary>
-		void LoadCharacterData();
-
-		/// <summary>
-		/// Loads all the data about one character in the texture atlas and converts it all from 'pixels' to 'screen-space' before storing.
+		/// Loads in data about each character from the texture atlas and converts it all from 'pixels' to 'screen-space' before storing. And stores the data in the <seealso cref="Character"/> class.
 		/// The effects of padding are also removed from the data.
 		/// </summary>
-		/// </param>
-		/// <returns> The data about the character. </returns>
-		FontCharacter *LoadCharacter();
+		void LoadCharacterData();
 
 		/// <summary>
 		/// Gets the {@code int} value of the variable with a certain name on the current line.

--- a/Sources/Fonts/FontMetafile.hpp
+++ b/Sources/Fonts/FontMetafile.hpp
@@ -28,17 +28,17 @@ namespace fl
 		int m_paddingHeight;
 		double m_maxSizeY;
 	public:
-		static FontMetafile *Resource(const std::string &filename)
+		static std::shared_ptr<FontMetafile> Resource(const std::string &filename)
 		{
-			IResource *resource = Resources::Get()->Get(filename);
+			auto resource = Resources::Get()->Get(filename);
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<FontMetafile *>(resource);
+				return std::dynamic_pointer_cast<FontMetafile>(resource);
 			}
 
-			FontMetafile *result = new FontMetafile(filename);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<FontMetafile>(filename);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 

--- a/Sources/Fonts/FontType.cpp
+++ b/Sources/Fonts/FontType.cpp
@@ -10,7 +10,5 @@ namespace fl
 
 	FontType::~FontType()
 	{
-		delete m_texture;
-		delete m_metadata;
 	}
 }

--- a/Sources/Fonts/FontType.hpp
+++ b/Sources/Fonts/FontType.hpp
@@ -11,8 +11,8 @@ namespace fl
 	class FL_EXPORT FontType
 	{
 	private:
-		Texture *m_texture;
-		FontMetafile *m_metadata;
+		std::shared_ptr<Texture> m_texture;
+		std::shared_ptr<FontMetafile> m_metadata;
 	public:
 		/// <summary>
 		/// Creates a new text loader.
@@ -26,8 +26,8 @@ namespace fl
 		/// </summary>
 		~FontType();
 
-		Texture *GetTexture() const { return m_texture; }
+		std::shared_ptr<Texture> GetTexture() const { return m_texture; }
 
-		FontMetafile *GetMetadata() const { return m_metadata; }
+		std::shared_ptr<FontMetafile> GetMetadata() const { return m_metadata; }
 	};
 }

--- a/Sources/Fonts/FontWord.cpp
+++ b/Sources/Fonts/FontWord.cpp
@@ -3,7 +3,7 @@
 namespace fl
 {
 	FontWord::FontWord() :
-		m_characters(std::vector<FontCharacter *>()),
+		m_characters(std::vector<FontCharacter>()),
 		m_width(0.0)
 	{
 	}
@@ -12,10 +12,10 @@ namespace fl
 	{
 	}
 
-	bool FontWord::AddCharacter(FontCharacter *c, const float &kerning)
+	bool FontWord::AddCharacter(const FontCharacter &character, const float &kerning)
 	{
-		m_characters.push_back(c);
-		m_width += kerning + c->GetAdvanceX();
+		m_characters.push_back(character);
+		m_width += kerning + character.GetAdvanceX();
 		return true;
 	}
 }

--- a/Sources/Fonts/FontWord.cpp
+++ b/Sources/Fonts/FontWord.cpp
@@ -14,7 +14,7 @@ namespace fl
 
 	bool FontWord::AddCharacter(const FontCharacter &character, const float &kerning)
 	{
-		m_characters.push_back(character);
+		m_characters.emplace_back(character);
 		m_width += kerning + character.GetAdvanceX();
 		return true;
 	}

--- a/Sources/Fonts/FontWord.hpp
+++ b/Sources/Fonts/FontWord.hpp
@@ -11,7 +11,7 @@ namespace fl
 	class FL_EXPORT FontWord
 	{
 	private:
-		std::vector<FontCharacter *> m_characters;
+		std::vector<FontCharacter> m_characters;
 		double m_width;
 	public:
 		/// <summary>
@@ -27,12 +27,12 @@ namespace fl
 		/// <summary>
 		/// Adds a character to the end of the current word and increases the screen-space width of the word.
 		/// </summary>
-		/// <param name="c"> The character to be added. </param>
+		/// <param name="character"> The character to be added. </param>
 		/// <param name="kerning"> The character kerning. </param>
 		/// <returns> {@code true} if the character has successfully been added to the word. </returns>
-		bool AddCharacter(FontCharacter *c, const float &kerning);
+		bool AddCharacter(const FontCharacter &character, const float &kerning);
 
-		std::vector<FontCharacter *> GetCharacters() const { return m_characters; }
+		std::vector<FontCharacter> GetCharacters() const { return m_characters; }
 
 		double GetWidth() const { return m_width; }
 	};

--- a/Sources/Fonts/RendererFonts.cpp
+++ b/Sources/Fonts/RendererFonts.cpp
@@ -18,7 +18,7 @@ namespace fl
 	{
 		m_pipeline->BindPipeline(commandBuffer);
 
-		for (auto screenObject : *Uis::Get()->GetObjects())
+		for (auto screenObject : Uis::Get()->GetObjects())
 		{
 			if (!screenObject->IsVisible())
 			{

--- a/Sources/Fonts/RendererFonts.cpp
+++ b/Sources/Fonts/RendererFonts.cpp
@@ -4,19 +4,18 @@ namespace fl
 {
 	RendererFonts::RendererFonts(const GraphicsStage &graphicsStage) :
 		IRenderer(),
-		m_pipeline(new Pipeline(graphicsStage, PipelineCreate({"Resources/Shaders/Fonts/Font.vert", "Resources/Shaders/Fonts/Font.frag"},
+		m_pipeline(Pipeline(graphicsStage, PipelineCreate({"Resources/Shaders/Fonts/Font.vert", "Resources/Shaders/Fonts/Font.frag"},
 			VertexModel::GetVertexInput(), PIPELINE_MODE_POLYGON_NO_DEPTH, PIPELINE_POLYGON_MODE_FILL, PIPELINE_CULL_MODE_BACK), {}))
 	{
 	}
 
 	RendererFonts::~RendererFonts()
 	{
-		delete m_pipeline;
 	}
 
 	void RendererFonts::Render(const CommandBuffer &commandBuffer, const Vector4 &clipPlane, const ICamera &camera)
 	{
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
 		for (auto screenObject : Uis::Get()->GetObjects())
 		{
@@ -29,7 +28,7 @@ namespace fl
 
 			if (object != nullptr)
 			{
-				object->CmdRender(commandBuffer, *m_pipeline);
+				object->CmdRender(commandBuffer, m_pipeline);
 			}
 		}
 	}

--- a/Sources/Fonts/RendererFonts.hpp
+++ b/Sources/Fonts/RendererFonts.hpp
@@ -10,7 +10,7 @@ namespace fl
 		public IRenderer
 	{
 	private:
-		Pipeline *m_pipeline;
+		Pipeline m_pipeline;
 	public:
 		RendererFonts(const GraphicsStage &graphicsStage);
 

--- a/Sources/Fonts/Text.cpp
+++ b/Sources/Fonts/Text.cpp
@@ -16,8 +16,8 @@ namespace fl
 		m_maxWidth(maxWidth),
 		m_kerning(kerning),
 		m_leading(leading),
-		m_textColour(new Colour("#ffffff")),
-		m_borderColour(new Colour("#000000")),
+		m_textColour(Colour("#ffffff")),
+		m_borderColour(Colour("#000000")),
 		m_solidBorder(false),
 		m_glowBorder(false),
 		m_glowDriver(new DriverConstant(0.0f)),
@@ -33,9 +33,6 @@ namespace fl
 	{
 		delete m_descriptorSet;
 		delete m_uniformObject;
-
-		delete m_textColour;
-		delete m_borderColour;
 
 		delete m_glowDriver;
 		delete m_borderDriver;
@@ -55,8 +52,8 @@ namespace fl
 
 		// Updates uniforms.
 		m_uniformObject->Push("transform", *GetScreenTransform());
-		m_uniformObject->Push("colour", *m_textColour);
-		m_uniformObject->Push("borderColour", *m_borderColour);
+		m_uniformObject->Push("colour", m_textColour);
+		m_uniformObject->Push("borderColour", m_borderColour);
 		m_uniformObject->Push("borderSizes", Vector2(GetTotalBorderSize(), GetGlowSize()));
 		m_uniformObject->Push("edgeData", Vector2(CalculateEdgeStart(), CalculateAntialiasSize()));
 		m_uniformObject->Push("alpha", GetAlpha());
@@ -191,7 +188,8 @@ namespace fl
 		NormalizeQuad(&bounding, vertices);
 
 		// Loads the mesh data.
-		m_model = std::make_shared<Model>(vertices);
+		delete m_model;
+		m_model = new Model(vertices);
 		GetRectangle()->SetDimensions(Vector2(bounding.m_x, bounding.m_y));
 	}
 

--- a/Sources/Fonts/Text.cpp
+++ b/Sources/Fonts/Text.cpp
@@ -82,7 +82,7 @@ namespace fl
 		vkCmdSetScissor(commandBuffer.GetVkCommandBuffer(), 0, 1, &scissorRect);
 
 		// Draws the object.
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 
@@ -211,7 +211,7 @@ namespace fl
 
 					if (!added)
 					{
-						lines.push_back(currentLine);
+						lines.emplace_back(currentLine);
 						currentLine = FontLine(m_fontType->GetMetadata()->GetSpaceWidth(), m_maxWidth);
 						currentLine.AddWord(currentWord);
 					}
@@ -230,7 +230,7 @@ namespace fl
 
 			if (i != textLines.size() - 1)
 			{
-				lines.push_back(currentLine);
+				lines.emplace_back(currentLine);
 				currentLine = FontLine(m_fontType->GetMetadata()->GetSpaceWidth(), m_maxWidth);
 				currentLine.AddWord(currentWord);
 			}
@@ -246,12 +246,12 @@ namespace fl
 
 		if (!added)
 		{
-			lines.push_back(currentLine);
+			lines.emplace_back(currentLine);
 			currentLine = FontLine(m_fontType->GetMetadata()->GetSpaceWidth(), m_maxWidth);
 			currentLine.AddWord(currentWord);
 		}
 
-		lines.push_back(currentLine);
+		lines.emplace_back(currentLine);
 	}
 
 	std::vector<IVertex *> Text::CreateQuad(const std::vector<FontLine> &lines)
@@ -330,7 +330,7 @@ namespace fl
 	void Text::AddVertex(const double &vx, const double &vy, const double &tx, const double &ty, std::vector<IVertex *> &vertices)
 	{
 		IVertex *vertex = new VertexModel(Vector3(static_cast<float>(vx), static_cast<float>(vy), 0.0f), Vector2(static_cast<float>(tx), static_cast<float>(ty)));
-		vertices.push_back(vertex);
+		vertices.emplace_back(vertex);
 	}
 
 	void Text::NormalizeQuad(Vector2 *bounding, std::vector<IVertex *> &vertices)

--- a/Sources/Fonts/Text.cpp
+++ b/Sources/Fonts/Text.cpp
@@ -33,7 +33,6 @@ namespace fl
 	{
 		delete m_descriptorSet;
 		delete m_uniformObject;
-		delete m_model;
 
 		delete m_textColour;
 		delete m_borderColour;
@@ -192,8 +191,7 @@ namespace fl
 		NormalizeQuad(&bounding, vertices);
 
 		// Loads the mesh data.
-		delete m_model;
-		m_model = new Model(vertices);
+		m_model = std::make_shared<Model>(vertices);
 		GetRectangle()->SetDimensions(Vector2(bounding.m_x, bounding.m_y));
 	}
 

--- a/Sources/Fonts/Text.cpp
+++ b/Sources/Fonts/Text.cpp
@@ -4,10 +4,10 @@
 
 namespace fl
 {
-	Text::Text(UiObject *parent, const UiBound &rectangle, const float &fontSize, const std::string &text, FontType *fontType, const FontJustify &justify, const float &maxWidth, const float &kerning, const float &leading) :
+	Text::Text(UiObject *parent, const UiBound &rectangle, const float &fontSize, const std::string &text, std::shared_ptr<FontType> fontType, const FontJustify &justify, const float &maxWidth, const float &kerning, const float &leading) :
 		UiObject(parent, rectangle),
-		m_descriptorSet(new DescriptorsHandler()),
-		m_uniformObject(new UniformHandler()),
+		m_descriptorSet(DescriptorsHandler()),
+		m_uniformObject(UniformHandler()),
 		m_model(nullptr),
 		m_string(text),
 		m_newString(""),
@@ -31,16 +31,13 @@ namespace fl
 
 	Text::~Text()
 	{
-		delete m_descriptorSet;
-		delete m_uniformObject;
-
 		delete m_glowDriver;
 		delete m_borderDriver;
 	}
 
 	void Text::UpdateObject()
 	{
-		if (IsLoaded() && m_newString != "")
+		if (IsLoaded() && !m_newString.empty())
 		{
 			m_string = m_newString;
 			LoadText();
@@ -51,12 +48,12 @@ namespace fl
 		m_borderSize = m_borderDriver->Update(Engine::Get()->GetDelta());
 
 		// Updates uniforms.
-		m_uniformObject->Push("transform", *GetScreenTransform());
-		m_uniformObject->Push("colour", m_textColour);
-		m_uniformObject->Push("borderColour", m_borderColour);
-		m_uniformObject->Push("borderSizes", Vector2(GetTotalBorderSize(), GetGlowSize()));
-		m_uniformObject->Push("edgeData", Vector2(CalculateEdgeStart(), CalculateAntialiasSize()));
-		m_uniformObject->Push("alpha", GetAlpha());
+		m_uniformObject.Push("transform", *GetScreenTransform());
+		m_uniformObject.Push("colour", m_textColour);
+		m_uniformObject.Push("borderColour", m_borderColour);
+		m_uniformObject.Push("borderSizes", Vector2(GetTotalBorderSize(), GetGlowSize()));
+		m_uniformObject.Push("edgeData", Vector2(CalculateEdgeStart(), CalculateAntialiasSize()));
+		m_uniformObject.Push("alpha", GetAlpha());
 	}
 
 	void Text::CmdRender(const CommandBuffer &commandBuffer, const Pipeline &pipeline)
@@ -68,11 +65,11 @@ namespace fl
 		}
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboObject", m_uniformObject);
-		m_descriptorSet->Push("samplerColour", m_fontType->GetTexture());
-		bool descriptorsSet = m_descriptorSet->Update(pipeline);
+		m_descriptorSet.Push("UboObject", m_uniformObject);
+		m_descriptorSet.Push("samplerColour", m_fontType->GetTexture());
+		bool updateSuccess = m_descriptorSet.Update(pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}
@@ -85,7 +82,7 @@ namespace fl
 		vkCmdSetScissor(commandBuffer.GetVkCommandBuffer(), 0, 1, &scissorRect);
 
 		// Draws the object.
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 
@@ -178,11 +175,6 @@ namespace fl
 		auto lines = CreateStructure();
 		auto vertices = CreateQuad(lines);
 
-		for (auto line : lines)
-		{
-			delete line;
-		}
-
 		// Calculates the bounds and normalizes the vertices.
 		Vector2 bounding = Vector2();
 		NormalizeQuad(&bounding, vertices);
@@ -193,11 +185,11 @@ namespace fl
 		GetRectangle()->SetDimensions(Vector2(bounding.m_x, bounding.m_y));
 	}
 
-	std::vector<FontLine *> Text::CreateStructure()
+	std::vector<FontLine> Text::CreateStructure()
 	{
-		auto lines = std::vector<FontLine *>();
-		auto currentLine = new FontLine(m_fontType->GetMetadata()->GetSpaceWidth(), m_maxWidth);
-		auto currentWord = new FontWord();
+		auto lines = std::vector<FontLine>();
+		auto currentLine = FontLine(m_fontType->GetMetadata()->GetSpaceWidth(), m_maxWidth);
+		auto currentWord = FontWord();
 
 		auto formattedText = FormatString::Replace(m_string, "\t", "    ");
 		auto textLines = FormatString::Split(formattedText, "\n", true);
@@ -215,32 +207,32 @@ namespace fl
 
 				if (ascii == FontMetafile::SPACE_ASCII)
 				{
-					bool added = currentLine->AddWord(currentWord);
+					bool added = currentLine.AddWord(currentWord);
 
 					if (!added)
 					{
 						lines.push_back(currentLine);
-						currentLine = new FontLine(m_fontType->GetMetadata()->GetSpaceWidth(), m_maxWidth);
-						currentLine->AddWord(currentWord);
+						currentLine = FontLine(m_fontType->GetMetadata()->GetSpaceWidth(), m_maxWidth);
+						currentLine.AddWord(currentWord);
 					}
 
-					currentWord = new FontWord();
+					currentWord = FontWord();
 					continue;
 				}
 
 				auto character = m_fontType->GetMetadata()->GetCharacter(ascii);
 
-				if (character != nullptr)
+				if (character.GetId() != -1)
 				{
-					currentWord->AddCharacter(character, m_kerning);
+					currentWord.AddCharacter(character, m_kerning);
 				}
 			}
 
 			if (i != textLines.size() - 1)
 			{
 				lines.push_back(currentLine);
-				currentLine = new FontLine(m_fontType->GetMetadata()->GetSpaceWidth(), m_maxWidth);
-				currentLine->AddWord(currentWord);
+				currentLine = FontLine(m_fontType->GetMetadata()->GetSpaceWidth(), m_maxWidth);
+				currentLine.AddWord(currentWord);
 			}
 		}
 
@@ -248,21 +240,21 @@ namespace fl
 		return lines;
 	}
 
-	void Text::CompleteStructure(std::vector<FontLine *> &lines, FontLine *currentLine, FontWord *currentWord)
+	void Text::CompleteStructure(std::vector<FontLine> &lines, FontLine &currentLine, const FontWord &currentWord)
 	{
-		bool added = currentLine->AddWord(currentWord);
+		bool added = currentLine.AddWord(currentWord);
 
 		if (!added)
 		{
 			lines.push_back(currentLine);
-			currentLine = new FontLine(m_fontType->GetMetadata()->GetSpaceWidth(), m_maxWidth);
-			currentLine->AddWord(currentWord);
+			currentLine = FontLine(m_fontType->GetMetadata()->GetSpaceWidth(), m_maxWidth);
+			currentLine.AddWord(currentWord);
 		}
 
 		lines.push_back(currentLine);
 	}
 
-	std::vector<IVertex *> Text::CreateQuad(std::vector<FontLine *> lines)
+	std::vector<IVertex *> Text::CreateQuad(const std::vector<FontLine> &lines)
 	{
 		auto vertices = std::vector<IVertex *>();
 		//m_numberLines = static_cast<int>(lines.size());
@@ -279,27 +271,27 @@ namespace fl
 				cursorX = 0.0;
 				break;
 			case JUSTIFY_CENTRE:
-				cursorX = (line->GetMaxLength() - line->GetCurrentLineLength()) / 2.0;
+				cursorX = (line.GetMaxLength() - line.GetCurrentLineLength()) / 2.0;
 				break;
 			case JUSTIFY_RIGHT:
-				cursorX = line->GetMaxLength() - line->GetCurrentLineLength();
+				cursorX = line.GetMaxLength() - line.GetCurrentLineLength();
 				break;
 			case JUSTIFY_FULLY:
 				cursorX = 0.0;
 				break;
 			}
 
-			for (auto word : line->GetWords())
+			for (auto word : line.GetWords())
 			{
-				for (auto letter : word->GetCharacters())
+				for (auto letter : word.GetCharacters())
 				{
-					AddVerticesForCharacter(cursorX, cursorY, *letter, vertices);
-					cursorX += m_kerning + letter->GetAdvanceX();
+					AddVerticesForCharacter(cursorX, cursorY, letter, vertices);
+					cursorX += m_kerning + letter.GetAdvanceX();
 				}
 
 				if (m_justify == JUSTIFY_FULLY && lineOrder > 1)
 				{
-					cursorX += (line->GetMaxLength() - line->GetCurrentWordsLength()) / line->GetWords().size();
+					cursorX += (line.GetMaxLength() - line.GetCurrentWordsLength()) / line.GetWords().size();
 				}
 				else
 				{

--- a/Sources/Fonts/Text.hpp
+++ b/Sources/Fonts/Text.hpp
@@ -31,8 +31,8 @@ namespace fl
 		public UiObject
 	{
 	private:
-		DescriptorsHandler *m_descriptorSet;
-		UniformHandler *m_uniformObject;
+		DescriptorsHandler m_descriptorSet;
+		UniformHandler m_uniformObject;
 
 		Model *m_model;
 
@@ -40,7 +40,7 @@ namespace fl
 		std::string m_newString;
 		FontJustify m_justify;
 
-		FontType *m_fontType;
+		std::shared_ptr<FontType> m_fontType;
 		float m_maxWidth;
 		float m_kerning;
 		float m_leading;
@@ -68,7 +68,7 @@ namespace fl
 		/// <param name="maxWidth"> The maximum length of a line of this text. </param>
 		/// <param name="kerning"> The kerning (type character spacing multiplier) of this text. </param>
 		/// <param name="leading"> The leading (vertical line spacing multiplier) of this text. </param>
-		Text(UiObject *parent, const UiBound &rectangle, const float &fontSize, const std::string &text, FontType *fontType = Uis::Get()->m_proximaNova->GetRegular(), const FontJustify &justify = JUSTIFY_LEFT, const float &maxWidth = 1.0f, const float &kerning = 0.0f, const float &leading = 0.0f);
+		Text(UiObject *parent, const UiBound &rectangle, const float &fontSize, const std::string &text, std::shared_ptr<FontType> fontType = Uis::Get()->m_proximaNova->GetRegular(), const FontJustify &justify = JUSTIFY_LEFT, const float &maxWidth = 1.0f, const float &kerning = 0.0f, const float &leading = 0.0f);
 
 		/// <summary>
 		/// Deconstructor for the text.
@@ -143,7 +143,7 @@ namespace fl
 		/// Gets the font used by this text.
 		/// </summary>
 		/// <returns> The font used by this text. </returns>
-		FontType *GetFontType() const { return m_fontType; }
+		std::shared_ptr<FontType> GetFontType() const { return m_fontType; }
 
 		/// <summary>
 		/// Gets font type texture for this text.
@@ -230,11 +230,11 @@ namespace fl
 		/// </summary>
 		void LoadText();
 
-		std::vector<FontLine *> CreateStructure();
+		std::vector<FontLine> CreateStructure();
 
-		void CompleteStructure(std::vector<FontLine *> &lines, FontLine *currentLine, FontWord *currentWord);
+		void CompleteStructure(std::vector<FontLine> &lines, FontLine &currentLine, const FontWord &currentWord);
 
-		std::vector<IVertex *> CreateQuad(std::vector<FontLine *> lines);
+		std::vector<IVertex *> CreateQuad(const std::vector<FontLine> &lines);
 
 		void AddVerticesForCharacter(const double &cursorX, const double &cursorY, const FontCharacter &character, std::vector<IVertex *> &vertices);
 

--- a/Sources/Fonts/Text.hpp
+++ b/Sources/Fonts/Text.hpp
@@ -34,7 +34,7 @@ namespace fl
 		DescriptorsHandler *m_descriptorSet;
 		UniformHandler *m_uniformObject;
 
-		std::shared_ptr<Model> m_model;
+		Model *m_model;
 
 		std::string m_string;
 		std::string m_newString;
@@ -45,8 +45,8 @@ namespace fl
 		float m_kerning;
 		float m_leading;
 
-		Colour *m_textColour;
-		Colour *m_borderColour;
+		Colour m_textColour;
+		Colour m_borderColour;
 		bool m_solidBorder;
 		bool m_glowBorder;
 
@@ -83,7 +83,7 @@ namespace fl
 		/// Gets the text model, which contains all the vertex data for the quads on which the text will be rendered.
 		/// </summary>
 		/// <returns> The model of the text. </returns>
-		std::shared_ptr<Model> GetModel() const { return m_model; }
+		Model *GetModel() const { return m_model; }
 
 		/// <summary>
 		/// Gets the string of text represented.
@@ -155,25 +155,25 @@ namespace fl
 		/// Gets the colour of the text.
 		/// </summary>
 		/// <returns> The colour of the text. </returns>
-		Colour *GetTextColour() const { return m_textColour; }
+		Colour GetTextColour() const { return m_textColour; }
 
 		/// <summary>
 		/// Sets the colour of the text.
 		/// </summary>
 		/// <param name="textColour"> The new colour of the text. </param>
-		void SetTextColour(const Colour &textColour) { *m_textColour = textColour; }
+		void SetTextColour(const Colour &textColour) { m_textColour = textColour; }
 
 		/// <summary>
 		/// Gets the border colour of the text. This is used with border and glow drivers.
 		/// </summary>
 		/// <returns> The border colour of the text. </returns>
-		Colour *GetBorderColour() const { return m_borderColour; }
+		Colour GetBorderColour() const { return m_borderColour; }
 
 		/// <summary>
 		/// Sets the border colour of the text. This is used with border and glow drivers.
 		/// </summary>
 		/// <param name="borderColour"> The new border colour of the text. </param>
-		void SetBorderColour(const Colour &borderColour) { *m_borderColour = borderColour; }
+		void SetBorderColour(const Colour &borderColour) { m_borderColour = borderColour; }
 
 		/// <summary>
 		/// Sets a new border driver, will disable glowing.

--- a/Sources/Fonts/Text.hpp
+++ b/Sources/Fonts/Text.hpp
@@ -34,7 +34,7 @@ namespace fl
 		DescriptorsHandler *m_descriptorSet;
 		UniformHandler *m_uniformObject;
 
-		Model *m_model;
+		std::shared_ptr<Model> m_model;
 
 		std::string m_string;
 		std::string m_newString;
@@ -83,7 +83,7 @@ namespace fl
 		/// Gets the text model, which contains all the vertex data for the quads on which the text will be rendered.
 		/// </summary>
 		/// <returns> The model of the text. </returns>
-		Model *GetModel() const { return m_model; }
+		std::shared_ptr<Model> GetModel() const { return m_model; }
 
 		/// <summary>
 		/// Gets the string of text represented.
@@ -149,7 +149,7 @@ namespace fl
 		/// Gets font type texture for this text.
 		/// </summary>
 		/// <returns> The texts texture. </returns>
-		Texture *GetTexture() const { return m_fontType->GetTexture(); }
+		std::shared_ptr<Texture> GetTexture() const { return m_fontType->GetTexture(); }
 
 		/// <summary>
 		/// Gets the colour of the text.

--- a/Sources/Guis/Gui.cpp
+++ b/Sources/Guis/Gui.cpp
@@ -61,7 +61,7 @@ namespace fl
 		vkCmdSetScissor(commandBuffer.GetVkCommandBuffer(), 0, 1, &scissorRect);
 
 		// Draws the object.
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Guis/Gui.cpp
+++ b/Sources/Guis/Gui.cpp
@@ -4,7 +4,7 @@
 
 namespace fl
 {
-	Gui::Gui(UiObject *parent, const UiBound &rectangle, Texture *texture, const int &selectedRow) :
+	Gui::Gui(UiObject *parent, const UiBound &rectangle, std::shared_ptr<Texture> texture, const int &selectedRow) :
 		UiObject(parent, rectangle),
 		m_descriptorSet(new DescriptorsHandler()),
 		m_uniformObject(new UniformHandler()),
@@ -20,7 +20,6 @@ namespace fl
 	{
 		delete m_descriptorSet;
 		delete m_uniformObject;
-		delete m_model;
 		delete m_atlasOffset;
 		delete m_colourOffset;
 	}

--- a/Sources/Guis/Gui.cpp
+++ b/Sources/Guis/Gui.cpp
@@ -6,37 +6,33 @@ namespace fl
 {
 	Gui::Gui(UiObject *parent, const UiBound &rectangle, std::shared_ptr<Texture> texture, const int &selectedRow) :
 		UiObject(parent, rectangle),
-		m_descriptorSet(new DescriptorsHandler()),
-		m_uniformObject(new UniformHandler()),
+		m_descriptorSet(DescriptorsHandler()),
+		m_uniformObject(UniformHandler()),
 		m_model(ShapeRectangle::Resource(0.0f, 1.0f)),
 		m_texture(texture),
 		m_selectedRow(selectedRow),
-		m_atlasOffset(new Vector2()),
-		m_colourOffset(new Colour(1.0f, 1.0f, 1.0f, 1.0f))
+		m_atlasOffset(Vector2()),
+		m_colourOffset(Colour(1.0f, 1.0f, 1.0f, 1.0f))
 	{
 	}
 
 	Gui::~Gui()
 	{
-		delete m_descriptorSet;
-		delete m_uniformObject;
-		delete m_atlasOffset;
-		delete m_colourOffset;
 	}
 
 	void Gui::UpdateObject()
 	{
-		const int numberOfRows = m_texture != nullptr ? m_texture->GetNumberOfRows() : 1;
-		const int column = m_selectedRow % numberOfRows;
-		const int row = m_selectedRow / numberOfRows;
-		*m_atlasOffset = Vector2(static_cast<float>(column / numberOfRows), static_cast<float>(row / numberOfRows));
+		int numberOfRows = m_texture != nullptr ? m_texture->GetNumberOfRows() : 1;
+		int column = m_selectedRow % numberOfRows;
+		int row = m_selectedRow / numberOfRows;
+		m_atlasOffset = Vector2(static_cast<float>(column) / static_cast<float>(numberOfRows), static_cast<float>(row) / static_cast<float>(numberOfRows));
 
 		// Updates uniforms.
-		m_uniformObject->Push("transform", *GetScreenTransform());
-		m_uniformObject->Push("colourOffset", *m_colourOffset);
-		m_uniformObject->Push("atlasOffset", *m_atlasOffset);
-		m_uniformObject->Push("atlasRows", static_cast<float>(m_texture->GetNumberOfRows()));
-		m_uniformObject->Push("alpha", GetAlpha());
+		m_uniformObject.Push("transform", *GetScreenTransform());
+		m_uniformObject.Push("colourOffset", m_colourOffset);
+		m_uniformObject.Push("atlasOffset", m_atlasOffset);
+		m_uniformObject.Push("atlasRows", static_cast<float>(m_texture->GetNumberOfRows()));
+		m_uniformObject.Push("alpha", GetAlpha());
 	}
 
 	void Gui::CmdRender(const CommandBuffer &commandBuffer, const Pipeline &pipeline)
@@ -48,11 +44,11 @@ namespace fl
 		}
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboObject", m_uniformObject);
-		m_descriptorSet->Push("samplerColour", m_texture);
-		bool descriptorsSet = m_descriptorSet->Update(pipeline);
+		m_descriptorSet.Push("UboObject", m_uniformObject);
+		m_descriptorSet.Push("samplerColour", m_texture);
+		bool updateSuccess = m_descriptorSet.Update(pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}
@@ -65,7 +61,7 @@ namespace fl
 		vkCmdSetScissor(commandBuffer.GetVkCommandBuffer(), 0, 1, &scissorRect);
 
 		// Draws the object.
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Guis/Gui.hpp
+++ b/Sources/Guis/Gui.hpp
@@ -19,8 +19,8 @@ namespace fl
 		DescriptorsHandler *m_descriptorSet;
 		UniformHandler *m_uniformObject;
 
-		Model *m_model;
-		Texture *m_texture;
+		std::shared_ptr<Model> m_model;
+		std::shared_ptr<Texture> m_texture;
 		int m_selectedRow;
 
 		Vector2 *m_atlasOffset;
@@ -32,7 +32,7 @@ namespace fl
 		/// <param name="rectangle"> The rectangle that will represent the bounds of the ui object. </param>
 		/// <param name="texture"> The objects texture. </param>
 		/// <param name="selectedRow"> The default row of the texture to render from. </param>
-		Gui(UiObject *parent, const UiBound &rectangle, Texture *texture, const int &selectedRow);
+		Gui(UiObject *parent, const UiBound &rectangle, std::shared_ptr<Texture> texture, const int &selectedRow);
 
 		/// <summary>
 		/// Deconstructor for the gui object.
@@ -43,9 +43,9 @@ namespace fl
 
 		void CmdRender(const CommandBuffer &commandBuffer, const Pipeline &pipeline);
 
-		Texture *GetTexture() const { return m_texture; }
+		std::shared_ptr<Texture> GetTexture() const { return m_texture; }
 
-		void SetTexture(Texture *texture) { m_texture = texture; }
+		void SetTexture(std::shared_ptr<Texture> texture) { m_texture = texture; }
 
 		int GetSelectedRow() const { return m_selectedRow; }
 

--- a/Sources/Guis/Gui.hpp
+++ b/Sources/Guis/Gui.hpp
@@ -16,15 +16,15 @@ namespace fl
 		public UiObject
 	{
 	private:
-		DescriptorsHandler *m_descriptorSet;
-		UniformHandler *m_uniformObject;
+		DescriptorsHandler m_descriptorSet;
+		UniformHandler m_uniformObject;
 
 		std::shared_ptr<Model> m_model;
 		std::shared_ptr<Texture> m_texture;
 		int m_selectedRow;
 
-		Vector2 *m_atlasOffset;
-		Colour *m_colourOffset;
+		Vector2 m_atlasOffset;
+		Colour m_colourOffset;
 	public:
 		/// <summary>
 		/// Creates a new GUI object.
@@ -51,10 +51,10 @@ namespace fl
 
 		void SetSelectedRow(const int &selectedRow) { m_selectedRow = selectedRow; }
 
-		Vector2 *GetAtlasOffset() const { return m_atlasOffset; }
+		Vector2 GetAtlasOffset() const { return m_atlasOffset; }
 
-		Colour *GetColourOffset() const { return m_colourOffset; }
+		Colour GetColourOffset() const { return m_colourOffset; }
 
-		void SetColourOffset(const Colour &colourOffset) { *m_colourOffset = colourOffset; }
+		void SetColourOffset(const Colour &colourOffset) { m_colourOffset = colourOffset; }
 	};
 }

--- a/Sources/Guis/RendererGuis.cpp
+++ b/Sources/Guis/RendererGuis.cpp
@@ -22,7 +22,7 @@ namespace fl
 	{
 		m_pipeline->BindPipeline(commandBuffer);
 
-		for (auto screenObject : *Uis::Get()->GetObjects())
+		for (auto screenObject : Uis::Get()->GetObjects())
 		{
 			if (!screenObject->IsVisible())
 			{

--- a/Sources/Guis/RendererGuis.cpp
+++ b/Sources/Guis/RendererGuis.cpp
@@ -8,19 +8,18 @@ namespace fl
 {
 	RendererGuis::RendererGuis(const GraphicsStage &graphicsStage) :
 		IRenderer(),
-		m_pipeline(new Pipeline(graphicsStage, PipelineCreate({"Resources/Shaders/Guis/Gui.vert", "Resources/Shaders/Guis/Gui.frag"},
+		m_pipeline(Pipeline(graphicsStage, PipelineCreate({"Resources/Shaders/Guis/Gui.vert", "Resources/Shaders/Guis/Gui.frag"},
 			VertexModel::GetVertexInput(), PIPELINE_MODE_POLYGON_NO_DEPTH, PIPELINE_POLYGON_MODE_FILL, PIPELINE_CULL_MODE_BACK), {}))
 	{
 	}
 
 	RendererGuis::~RendererGuis()
 	{
-		delete m_pipeline;
 	}
 
 	void RendererGuis::Render(const CommandBuffer &commandBuffer, const Vector4 &clipPlane, const ICamera &camera)
 	{
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
 		for (auto screenObject : Uis::Get()->GetObjects())
 		{
@@ -33,7 +32,7 @@ namespace fl
 
 			if (object != nullptr)
 			{
-				object->CmdRender(commandBuffer, *m_pipeline);
+				object->CmdRender(commandBuffer, m_pipeline);
 			}
 		}
 	}

--- a/Sources/Guis/RendererGuis.hpp
+++ b/Sources/Guis/RendererGuis.hpp
@@ -9,7 +9,7 @@ namespace fl
 		public IRenderer
 	{
 	private:
-		Pipeline *m_pipeline;
+		Pipeline m_pipeline;
 	public:
 		RendererGuis(const GraphicsStage &graphicsStage);
 

--- a/Sources/Helpers/FileSystem.cpp
+++ b/Sources/Helpers/FileSystem.cpp
@@ -83,7 +83,7 @@ namespace fl
 	{
 		if (!FileSystem::FileExists(filepath))
 		{
-			printf("File does not exist: '%s'\n", filepath.c_str());
+			fprintf(stderr, "File does not exist: '%s'\n", filepath.c_str());
 			return "";
 		}
 

--- a/Sources/Helpers/FormatString.cpp
+++ b/Sources/Helpers/FormatString.cpp
@@ -21,7 +21,7 @@ namespace fl
 				currentS = Trim(currentS);
 			}
 
-			arr.push_back(currentS);
+			arr.emplace_back(currentS);
 			current = strtok(nullptr, sep.c_str());
 		}
 
@@ -72,15 +72,15 @@ namespace fl
 
 	std::string FormatString::Trim(const std::string &str, const std::string &whitespace)
 	{
-		const auto strBegin = str.find_first_not_of(whitespace);
+		auto strBegin = str.find_first_not_of(whitespace);
 
 		if (strBegin == std::string::npos)
 		{
 			return "";
 		}
 
-		const auto strEnd = str.find_last_not_of(whitespace);
-		const auto strRange = strEnd - strBegin + 1;
+		auto strEnd = str.find_last_not_of(whitespace);
+		auto strRange = strEnd - strBegin + 1;
 
 		std::string result = str;
 		result = result.substr(strBegin, strRange);

--- a/Sources/Inputs/Joysticks.cpp
+++ b/Sources/Inputs/Joysticks.cpp
@@ -6,55 +6,49 @@ namespace fl
 {
 	Joysticks::Joysticks() :
 		IModule(),
-		m_connected(new std::vector<Joystick *>())
+		m_connected(std::array<Joystick, JOYSTICK_LAST + 1>())
 	{
-		for (int i = JoystickPort::JOYSTICK_1; i < JoystickPort::JOYSTICK_LAST; i++)
+		for (int i = JOYSTICK_1; i < JOYSTICK_LAST; i++)
 		{
-			auto joystick = new Joystick();
-			joystick->m_id = i;
-			joystick->m_connected = false;
-			m_connected->push_back(joystick);
+			Joystick joystick = Joystick();
+			joystick.m_id = i;
+			joystick.m_connected = false;
+			m_connected[i] = joystick;
 		}
 	}
 
 	Joysticks::~Joysticks()
 	{
-		for (auto joystick : *m_connected)
-		{
-			delete joystick;
-		}
-
-		delete m_connected;
 	}
 
 	void Joysticks::Update()
 	{
 		// For each joystick check if connected and update.
-		for (auto joystick : *m_connected)
+		for (auto joystick : m_connected)
 		{
-			if (glfwJoystickPresent(joystick->m_id))
+			if (glfwJoystickPresent(joystick.m_id))
 			{
-				if (!joystick->m_connected)
+				if (!joystick.m_connected)
 				{
-					printf("Joystick connected: '%s' to %i\n", glfwGetJoystickName(joystick->m_id), joystick->m_id);
-					joystick->m_connected = true;
-					joystick->m_name = glfwGetJoystickName(joystick->m_id);
+					printf("Joystick connected: '%s' to %i\n", glfwGetJoystickName(joystick.m_id), joystick.m_id);
+					joystick.m_connected = true;
+					joystick.m_name = glfwGetJoystickName(joystick.m_id);
 				}
 
-				joystick->m_axes = glfwGetJoystickAxes(joystick->m_id, &joystick->m_axeCount);
-				joystick->m_buttons = glfwGetJoystickButtons(joystick->m_id, &joystick->m_buttonCount);
+				joystick.m_axes = glfwGetJoystickAxes(joystick.m_id, &joystick.m_axeCount);
+				joystick.m_buttons = glfwGetJoystickButtons(joystick.m_id, &joystick.m_buttonCount);
 			}
 			else
 			{
-				if (joystick->m_connected)
+				if (joystick.m_connected)
 				{
-					printf("Joystick disconnected from %i\n", joystick->m_id);
-					joystick->m_connected = false;
-					joystick->m_name = "";
-					joystick->m_axes = nullptr;
-					joystick->m_buttons = nullptr;
-					joystick->m_axeCount = 0;
-					joystick->m_buttonCount = 0;
+					printf("Joystick disconnected from %i\n", joystick.m_id);
+					joystick.m_connected = false;
+					joystick.m_name = "";
+					joystick.m_axes = nullptr;
+					joystick.m_buttons = nullptr;
+					joystick.m_axeCount = 0;
+					joystick.m_buttonCount = 0;
 				}
 			}
 		}
@@ -67,7 +61,7 @@ namespace fl
 			return false;
 		}
 
-		return m_connected->at(port)->m_axes[axis];
+		return m_connected.at(port).m_axes[axis];
 	}
 
 	bool Joysticks::GetButton(const JoystickPort &port, const int &button) const
@@ -77,6 +71,6 @@ namespace fl
 			return false;
 		}
 
-		return m_connected->at(port)->m_buttons[button];
+		return m_connected.at(port).m_buttons[button];
 	}
 }

--- a/Sources/Inputs/Joysticks.hpp
+++ b/Sources/Inputs/Joysticks.hpp
@@ -27,7 +27,7 @@ namespace fl
 	};
 
 	/// <summary>
-	/// A definition for a connected joystick.
+	/// A definition for a GLFW managed joystick.
 	/// </summary>
 	struct FL_HIDDEN Joystick
 	{
@@ -48,7 +48,7 @@ namespace fl
 		public IModule
 	{
 	private:
-		std::vector<Joystick *> *m_connected;
+		std::array<Joystick, JOYSTICK_LAST + 1> m_connected;
 	public:
 		/// <summary>
 		/// Gets this engine instance.
@@ -76,14 +76,14 @@ namespace fl
 		/// </summary>
 		/// <param name="port"> The joystick to check connection with. </param>
 		/// <returns> If the joystick is connected. </returns>
-		bool IsConnected(const JoystickPort &port) const { return m_connected->at(port)->m_connected; }
+		bool IsConnected(const JoystickPort &port) const { return m_connected.at(port).m_connected; }
 
 		/// <summary>
 		/// Gets the name of the joystick.
 		/// </summary>
 		/// <param name="port"> The joystick to get the name of. </param>
 		/// <returns> The joysticks name. </returns>
-		const char *GetName(const JoystickPort &port) const { return m_connected->at(port)->m_name; }
+		const char *GetName(const JoystickPort &port) const { return m_connected.at(port).m_name; }
 
 		/// <summary>
 		/// Gets the value of a joysticks axis.
@@ -106,13 +106,13 @@ namespace fl
 		/// </summary>
 		/// <param name="port"> The joystick to the the axis count from. </param>
 		/// <returns> The number of axes the joystick offers. </returns>
-		int GetCountAxes(const JoystickPort &port) const { return m_connected->at(port)->m_axeCount; }
+		int GetCountAxes(const JoystickPort &port) const { return m_connected.at(port).m_axeCount; }
 
 		/// <summary>
 		/// Gets the number of buttons the joystick offers.
 		/// </summary>
 		/// <param name="port"> The joystick to the the button count from. </param>
 		/// <returns> The number of buttons the joystick offers. </returns>
-		int GetCountButtons(const JoystickPort &port) const { return m_connected->at(port)->m_buttonCount; }
+		int GetCountButtons(const JoystickPort &port) const { return m_connected.at(port).m_buttonCount; }
 	};
 }

--- a/Sources/Inputs/Keyboard.cpp
+++ b/Sources/Inputs/Keyboard.cpp
@@ -25,11 +25,11 @@ namespace fl
 
 	Keyboard::Keyboard() :
 		IModule(),
-		m_keyboardKeys(new int[Key::KEY_LAST + 1]),
+		m_keyboardKeys(std::array<int, KEY_LAST + 1>()),
 		m_keyboardChar(0)
 	{
 		// Sets the default state of the keys to released.
-		for (unsigned int i = 0; i < Key::KEY_LAST + 1; i++)
+		for (unsigned int i = 0; i < KEY_LAST + 1; i++)
 		{
 			m_keyboardKeys[i] = GLFW_RELEASE;
 		}
@@ -41,7 +41,6 @@ namespace fl
 
 	Keyboard::~Keyboard()
 	{
-		delete[] m_keyboardKeys;
 	}
 
 	void Keyboard::Update()
@@ -50,7 +49,7 @@ namespace fl
 
 	bool Keyboard::GetKey(const Key &key) const
 	{
-		if (key < 0 || key > Key::KEY_LAST + 1)
+		if (key < 0 || key > KEY_LAST + 1)
 		{
 			return false;
 		}

--- a/Sources/Inputs/Keyboard.cpp
+++ b/Sources/Inputs/Keyboard.cpp
@@ -10,7 +10,7 @@ namespace fl
 
 		if (key < 0 || key > Key::KEY_LAST)
 		{
-			printf("Invalid action attempted with key: '%i'\n", key);
+			fprintf(stderr, "Invalid action attempted with key: '%i'\n", key);
 		}
 		else
 		{

--- a/Sources/Inputs/Keyboard.hpp
+++ b/Sources/Inputs/Keyboard.hpp
@@ -148,7 +148,7 @@ namespace fl
 		public IModule
 	{
 	private:
-		int *m_keyboardKeys;
+		std::array<int, KEY_LAST + 1> m_keyboardKeys;
 		int m_keyboardChar;
 
 		friend void CallbackKey(GLFWwindow *window, int key, int scancode, int action, int mods);

--- a/Sources/Inputs/Mouse.cpp
+++ b/Sources/Inputs/Mouse.cpp
@@ -30,7 +30,7 @@ namespace fl
 	Mouse::Mouse() :
 		IModule(),
 		m_customMouse(""),
-		m_mouseButtons(new int[MouseButton::MOUSE_BUTTON_LAST + 1]),
+		m_mouseButtons(std::array<int, MOUSE_BUTTON_LAST + 1>()),
 		m_lastMousePositionX(0.5f),
 		m_lastMousePositionY(0.5f),
 		m_mousePositionX(0.5f),
@@ -43,7 +43,7 @@ namespace fl
 		m_lastCursorDisabled(false)
 	{
 		// Sets the default state of the buttons to released.
-		for (int i = 0; i < MouseButton::MOUSE_BUTTON_LAST + 1; i++)
+		for (int i = 0; i < MOUSE_BUTTON_LAST + 1; i++)
 		{
 			m_mouseButtons[i] = GLFW_RELEASE;
 		}
@@ -57,7 +57,6 @@ namespace fl
 
 	Mouse::~Mouse()
 	{
-		delete[] m_mouseButtons;
 	}
 
 	void Mouse::Update()
@@ -133,7 +132,7 @@ namespace fl
 
 	bool Mouse::GetButton(const MouseButton &button) const
 	{
-		if (button < 0 || button > MouseButton::MOUSE_BUTTON_LAST + 1)
+		if (button < 0 || button > MOUSE_BUTTON_LAST + 1)
 		{
 			return false;
 		}

--- a/Sources/Inputs/Mouse.cpp
+++ b/Sources/Inputs/Mouse.cpp
@@ -101,18 +101,18 @@ namespace fl
 
 			if (data == nullptr)
 			{
-				printf("Unable to load texture: '%s'.\n", m_customMouse.c_str());
+				fprintf(stderr, "Unable to load texture: '%s'.\n", m_customMouse.c_str());
+				return;
 			}
 
-			GLFWimage *image = new GLFWimage();
-			image->pixels = data;
-			image->width = width;
-			image->height = height;
+			GLFWimage image[1];
+			image[0].pixels = data;
+			image[0].width = width;
+			image[0].height = height;
 
 			GLFWcursor *cursor = glfwCreateCursor(image, 0, 0);
 			glfwSetCursor(Display::Get()->GetGlfwWindow(), cursor);
 			Texture::DeletePixels(data);
-			//	delete image;
 		}
 	}
 

--- a/Sources/Inputs/Mouse.hpp
+++ b/Sources/Inputs/Mouse.hpp
@@ -30,7 +30,7 @@ namespace fl
 	private:
 		std::string m_customMouse;
 
-		int *m_mouseButtons;
+		std::array<int, MOUSE_BUTTON_LAST + 1> m_mouseButtons;
 		float m_lastMousePositionX;
 		float m_lastMousePositionY;
 		float m_mousePositionX;

--- a/Sources/Lights/Fog.cpp
+++ b/Sources/Lights/Fog.cpp
@@ -2,8 +2,8 @@
 
 namespace fl
 {
-	Fog::Fog(Colour *colour, const float &density, const float &gradient, const float &lowerLimit, const float &upperLimit) :
-		m_colour(colour),
+	Fog::Fog(const Colour &colour, const float &density, const float &gradient, const float &lowerLimit, const float &upperLimit) :
+		m_colour(Colour(colour)),
 		m_density(density),
 		m_gradient(gradient),
 		m_lowerLimit(lowerLimit),
@@ -13,12 +13,11 @@ namespace fl
 
 	Fog::~Fog()
 	{
-		delete m_colour;
 	}
 
 	void Fog::Write(LoadedValue *destination)
 	{
-		m_colour->Write(destination->GetChild("colour", true));
+		m_colour.Write(destination->GetChild("colour", true));
 		destination->SetChild<float>("density", m_density);
 		destination->SetChild<float>("gradient", m_gradient);
 		destination->SetChild<float>("lowerLimit", m_lowerLimit);
@@ -27,7 +26,7 @@ namespace fl
 
 	Fog &Fog::operator=(const Fog &other)
 	{
-		*m_colour = *other.m_colour;
+		m_colour = other.m_colour;
 		m_density = other.m_density;
 		m_gradient = other.m_gradient;
 		m_lowerLimit = other.m_lowerLimit;
@@ -37,7 +36,7 @@ namespace fl
 
 	Fog &Fog::operator=(LoadedValue *source)
 	{
-		*m_colour = source->GetChild("colour");
+		m_colour = source->GetChild("colour");
 		m_density = source->GetChild("density")->Get<float>();
 		m_gradient = source->GetChild("gradient")->Get<float>();
 		m_lowerLimit = source->GetChild("lowerLimit")->Get<float>();

--- a/Sources/Lights/Fog.hpp
+++ b/Sources/Lights/Fog.hpp
@@ -11,7 +11,7 @@ namespace fl
 	class FL_EXPORT Fog
 	{
 	private:
-		Colour *m_colour;
+		Colour m_colour;
 		float m_density;
 		float m_gradient;
 		float m_lowerLimit;
@@ -25,16 +25,16 @@ namespace fl
 		/// <param name="gradient"> The gradient of the fog. </param>
 		/// <param name="lowerLimit"> At what height will the skybox fog begin to appear. </param>
 		/// <param name="upperLimit"> At what height will there be skybox no fog. </param>
-		Fog(Colour *colour, const float &density, const float &gradient, const float &lowerLimit, const float &upperLimit);
+		Fog(const Colour &colour, const float &density, const float &gradient, const float &lowerLimit, const float &upperLimit);
 
 		/// <summary>
 		/// Deconstructor for fog.
 		/// </summary>
 		~Fog();
 
-		Colour *GetColour() const { return m_colour; }
+		Colour GetColour() const { return m_colour; }
 
-		void SetColour(const Colour &colour) { *m_colour = colour; }
+		void SetColour(const Colour &colour) { m_colour = colour; }
 
 		float GetDensity() const { return m_density; }
 

--- a/Sources/Lights/Light.cpp
+++ b/Sources/Lights/Light.cpp
@@ -4,68 +4,58 @@ namespace fl
 {
 	Light::Light(const Colour &colour, const float &radius, const Vector3 &offset) :
 		Component(),
-		m_colour(new Colour(colour)),
-		m_radius(radius),
-		m_offset(new Vector3(offset)),
-		m_position(new Vector3())
+		m_colour(Colour(colour)),
+		m_position(Vector3()),
+		m_offset(Vector3(offset)),
+		m_radius(radius)
 	{
 	}
 
 	Light::Light(const Light &source) :
 		Component(),
-		m_colour(new Colour(*source.m_colour)),
-		m_radius(source.m_radius),
-		m_offset(new Vector3(*source.m_offset)),
-		m_position(new Vector3())
+		m_colour(Colour(source.m_colour)),
+		m_position(Vector3()),
+		m_offset(Vector3(source.m_offset)),
+		m_radius(source.m_radius)
 	{
 	}
 
 	Light::~Light()
 	{
-		delete m_colour;
-		delete m_offset;
-		delete m_position;
 	}
 
 	void Light::Update()
 	{
-		*m_position = *GetGameObject()->GetTransform()->GetPosition() + *m_offset;
+		m_position = GetGameObject()->GetTransform()->GetPosition() + m_offset;
 	}
 
 	void Light::Load(LoadedValue *value)
 	{
-		*m_colour = value->GetChild("Colour")->GetString();
+		m_colour = value->GetChild("Colour")->GetString();
+		m_offset = value->GetChild("Offset");
 		m_radius = value->GetChild("Radius")->Get<float>();
-		*m_offset = value->GetChild("Offset");
 	}
 
 	void Light::Write(LoadedValue *value)
 	{
-		value->GetChild("Colour", true)->SetString(m_colour->GetHex());
+		value->GetChild("Colour", true)->SetString(m_colour.GetHex());
+		m_offset.Write(value->GetChild("Offset", true));
 		value->GetChild("Radius", true)->Set(m_radius);
-		m_offset->Write(value->GetChild("Offset", true));
 	}
 
-	Light *Light::Set(const Colour &colour, const Vector3 &offset)
+	Light &Light::operator=(const Light &other)
 	{
-		*m_colour = colour;
-		*m_offset = offset;
-		return this;
+		m_colour = other.m_colour;
+		m_offset = other.m_offset;
+		m_radius = other.m_radius;
+		return *this;
 	}
 
-	Light *Light::Set(const Colour &colour, const float &radius, const Vector3 &offset)
+	Light &Light::operator=(LoadedValue *source)
 	{
-		*m_colour = colour;
-		m_radius = radius;
-		*m_offset = offset;
-		return this;
-	}
-
-	Light *Light::Set(const Light &source)
-	{
-		*m_colour = *source.m_colour;
-		m_radius = source.m_radius;
-		*m_offset = *source.m_offset;
-		return this;
+		m_colour = source->GetChild("colour");
+		m_offset = source->GetChild("offset");
+		m_radius = source->GetChild("radius")->Get<float>();
+		return *this;
 	}
 }

--- a/Sources/Lights/Light.hpp
+++ b/Sources/Lights/Light.hpp
@@ -15,10 +15,10 @@ namespace fl
 		public Component
 	{
 	private:
-		Colour *m_colour;
+		Colour m_colour;
+		Vector3 m_position;
+		Vector3 m_offset;
 		float m_radius;
-		Vector3 *m_offset;
-		Vector3 *m_position;
 	public:
 		/// <summary>
 		/// Creates a new point light.
@@ -26,7 +26,7 @@ namespace fl
 		/// <param name="colour"> The colour of the light. </param>
 		/// <param name="radius"> How far the light will have influence (-1 sets this to a directional light). </param>
 		/// <param name="offset"> The parent offset of the light. </param>
-		Light(const Colour &colour = Colour::WHITE, const float &radius = -1.0f, const Vector3 &offset = Vector3());
+		Light(const Colour &colour = Colour::WHITE, const float &radius = -1.0f, const Vector3 &offset = Vector3::ZERO);
 
 		/// <summary>
 		/// Creates a new point light from a source object.
@@ -45,46 +45,26 @@ namespace fl
 
 		void Write(LoadedValue *value) override;
 
-		/// <summary>
-		/// Sets values in the light.
-		/// </summary>
-		/// <param name="colour"> The colour of the light. </param>
-		/// <param name="offset"> The parent offset of the light. </param>
-		/// <returns> This. </returns>
-		Light *Set(const Colour &colour, const Vector3 &offset);
-
-		/// <summary>
-		/// Sets values in the light.
-		/// </summary>
-		/// <param name="colour"> The colour of the light. </param>
-		/// <param name="radius"> How far the light will have influence (-1 sets this to a directional light). </param>
-		/// <param name="offset"> The parent offset of the light. </param>
-		/// <returns> This. </returns>
-		Light *Set(const Colour &colour, const float &radius, const Vector3 &offset);
-
-		/// <summary>
-		/// Sets values in the light.
-		/// </summary>
-		/// <param name="source"> The source light object. </param>
-		/// <returns> This. </returns>
-		Light *Set(const Light &source);
-
 		std::string GetName() const override { return "Light"; };
 
-		Colour *GetColour() const { return m_colour; }
+		Colour GetColour() const { return m_colour; }
 
-		void SetColour(const Colour &colour) { *m_colour = colour; }
+		void SetColour(const Colour &colour) { m_colour = colour; }
 
 		float GetRadius() const { return m_radius; }
 
 		void SetRadius(const float &radius) { m_radius = radius; }
 
-		Vector3 *GetOffset() const { return m_offset; }
+		Vector3 GetPosition() const { return m_position; }
 
-		void SetOffset(const Vector3 &offset) { *m_offset = offset; }
+		void SetPosition(const Vector3 &position) { m_position = position; }
 
-		Vector3 *GetPosition() const { return m_position; }
+		Vector3 GetOffset() const { return m_offset; }
 
-		void SetPosition(const Vector3 &position) { *m_position = position; }
+		void SetOffset(const Vector3 &offset) { m_offset = offset; }
+
+		Light &operator=(const Light &other);
+
+		Light &operator=(LoadedValue *value);
 	};
 }

--- a/Sources/Materials/IMaterial.hpp
+++ b/Sources/Materials/IMaterial.hpp
@@ -28,9 +28,9 @@ namespace fl
 
 		virtual void Write(LoadedValue *destination) override = 0;
 
-		virtual void PushUniforms(UniformHandler *uniformObject) = 0;
+		virtual void PushUniforms(UniformHandler &uniformObject) = 0;
 
-		virtual void PushDescriptors(DescriptorsHandler *descriptorSet) = 0;
+		virtual void PushDescriptors(DescriptorsHandler &descriptorSet) = 0;
 
 		virtual std::string GetName() const override = 0;
 

--- a/Sources/Materials/IMaterial.hpp
+++ b/Sources/Materials/IMaterial.hpp
@@ -34,6 +34,6 @@ namespace fl
 
 		virtual std::string GetName() const override = 0;
 
-		virtual PipelineMaterial *GetMaterial() const = 0;
+		virtual std::shared_ptr<PipelineMaterial> GetMaterial() const = 0;
 	};
 }

--- a/Sources/Materials/MaterialDefault.cpp
+++ b/Sources/Materials/MaterialDefault.cpp
@@ -81,17 +81,17 @@ namespace fl
 
 		if (m_diffuseTexture != nullptr)
 		{
-			result.push_back(PipelineDefine("COLOUR_MAPPING", "TRUE"));
+			result.emplace_back(PipelineDefine("COLOUR_MAPPING", "TRUE"));
 		}
 
 		if (m_materialTexture != nullptr)
 		{
-			result.push_back(PipelineDefine("MATERIAL_MAPPING", "TRUE"));
+			result.emplace_back(PipelineDefine("MATERIAL_MAPPING", "TRUE"));
 		}
 
 		/*if (m_normalTexture != nullptr)
 		{
-			result.push_back({"NORMAL_MAPPING", "TRUE"});
+			result.emplace_back({"NORMAL_MAPPING", "TRUE"});
 		}*/
 
 		return result;

--- a/Sources/Materials/MaterialDefault.cpp
+++ b/Sources/Materials/MaterialDefault.cpp
@@ -6,7 +6,7 @@ namespace fl
 									 const float &metallic, const float &roughness, std::shared_ptr<Texture> materialTexture, std::shared_ptr<Texture> normalTexture,
 									 const bool &castsShadows, const bool &ignoreLighting, const bool &ignoreFog) :
 		IMaterial(),
-		m_baseColor(new Colour(baseColor)),
+		m_baseColor(Colour(baseColor)),
 		m_diffuseTexture(diffuseTexture),
 		m_metallic(metallic),
 		m_roughness(roughness),
@@ -22,7 +22,6 @@ namespace fl
 
 	MaterialDefault::~MaterialDefault()
 	{
-		delete m_baseColor;
 	}
 
 	void MaterialDefault::Update()
@@ -31,7 +30,7 @@ namespace fl
 
 	void MaterialDefault::Load(LoadedValue *value)
 	{
-		*m_baseColor = value->GetChild("Base Colour")->GetString();
+		m_baseColor = value->GetChild("Base Colour")->GetString();
 		TrySetDiffuseTexture(value->GetChild("Diffuse Texture")->GetString());
 
 		m_metallic = value->GetChild("Metallic")->Get<float>();
@@ -46,7 +45,7 @@ namespace fl
 
 	void MaterialDefault::Write(LoadedValue *destination)
 	{
-		destination->GetChild("Base Colour", true)->SetString(m_baseColor->GetHex());
+		destination->GetChild("Base Colour", true)->SetString(m_baseColor.GetHex());
 		destination->GetChild("Diffuse Texture", true)->SetString(m_diffuseTexture == nullptr ? "" : m_diffuseTexture->GetFilename());
 
 		destination->GetChild("Metallic", true)->Set(m_metallic);
@@ -59,21 +58,21 @@ namespace fl
 		destination->GetChild("Ignore Fog", true)->Set(m_ignoreFog);
 	}
 
-	void MaterialDefault::PushUniforms(UniformHandler *uniformObject)
+	void MaterialDefault::PushUniforms(UniformHandler &uniformObject)
 	{
-		uniformObject->Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
-		uniformObject->Push("baseColor", *m_baseColor);
-		uniformObject->Push("metallic", m_metallic);
-		uniformObject->Push("roughness", m_roughness);
-		uniformObject->Push("ignoreFog", static_cast<float>(m_ignoreFog));
-		uniformObject->Push("ignoreLighting", static_cast<float>(m_ignoreLighting));
+		uniformObject.Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
+		uniformObject.Push("baseColor", m_baseColor);
+		uniformObject.Push("metallic", m_metallic);
+		uniformObject.Push("roughness", m_roughness);
+		uniformObject.Push("ignoreFog", static_cast<float>(m_ignoreFog));
+		uniformObject.Push("ignoreLighting", static_cast<float>(m_ignoreLighting));
 	}
 
-	void MaterialDefault::PushDescriptors(DescriptorsHandler *descriptorSet)
+	void MaterialDefault::PushDescriptors(DescriptorsHandler &descriptorSet)
 	{
-		descriptorSet->Push("samplerDiffuse", m_diffuseTexture);
-		descriptorSet->Push("samplerMaterial", m_materialTexture);
-		descriptorSet->Push("samplerNormal", m_normalTexture);
+		descriptorSet.Push("samplerDiffuse", m_diffuseTexture);
+		descriptorSet.Push("samplerMaterial", m_materialTexture);
+		descriptorSet.Push("samplerNormal", m_normalTexture);
 	}
 
 	std::vector<PipelineDefine> MaterialDefault::GetDefines()

--- a/Sources/Materials/MaterialDefault.cpp
+++ b/Sources/Materials/MaterialDefault.cpp
@@ -2,8 +2,8 @@
 
 namespace fl
 {
-	MaterialDefault::MaterialDefault(const Colour &baseColor, Texture *diffuseTexture,
-									 const float &metallic, const float &roughness, Texture *materialTexture, Texture *normalTexture,
+	MaterialDefault::MaterialDefault(const Colour &baseColor, std::shared_ptr<Texture> diffuseTexture,
+									 const float &metallic, const float &roughness, std::shared_ptr<Texture> materialTexture, std::shared_ptr<Texture> normalTexture,
 									 const bool &castsShadows, const bool &ignoreLighting, const bool &ignoreFog) :
 		IMaterial(),
 		m_baseColor(new Colour(baseColor)),

--- a/Sources/Materials/MaterialDefault.hpp
+++ b/Sources/Materials/MaterialDefault.hpp
@@ -14,7 +14,7 @@ namespace fl
 		public IMaterial
 	{
 	private:
-		Colour *m_baseColor;
+		Colour m_baseColor;
 		std::shared_ptr<Texture> m_diffuseTexture;
 
 		float m_metallic;
@@ -41,17 +41,17 @@ namespace fl
 
 		void Write(LoadedValue *destination) override;
 
-		void PushUniforms(UniformHandler *uniformObject) override;
+		void PushUniforms(UniformHandler &uniformObject) override;
 
-		void PushDescriptors(DescriptorsHandler *descriptorSet) override;
+		void PushDescriptors(DescriptorsHandler &descriptorSet) override;
 
 		std::string GetName() const override { return "MaterialDefault"; };
 
 		std::vector<PipelineDefine> GetDefines();
 
-		Colour *GetBaseColor() const { return m_baseColor; }
+		Colour GetBaseColor() const { return m_baseColor; }
 
-		void SetBaseColor(const Colour &baseColor) { *m_baseColor = baseColor; }
+		void SetBaseColor(const Colour &baseColor) { m_baseColor = baseColor; }
 
 		std::shared_ptr<Texture> GetDiffuseTexture() const { return m_diffuseTexture; }
 

--- a/Sources/Materials/MaterialDefault.hpp
+++ b/Sources/Materials/MaterialDefault.hpp
@@ -15,21 +15,21 @@ namespace fl
 	{
 	private:
 		Colour *m_baseColor;
-		Texture *m_diffuseTexture;
+		std::shared_ptr<Texture> m_diffuseTexture;
 
 		float m_metallic;
 		float m_roughness;
-		Texture *m_materialTexture;
-		Texture *m_normalTexture;
+		std::shared_ptr<Texture> m_materialTexture;
+		std::shared_ptr<Texture> m_normalTexture;
 
 		bool m_castsShadows;
 		bool m_ignoreLighting;
 		bool m_ignoreFog;
 
-		PipelineMaterial *m_material;
+		std::shared_ptr<PipelineMaterial> m_material;
 	public:
-		MaterialDefault(const Colour &baseColor = Colour::WHITE, Texture *diffuseTexture = nullptr,
-						const float &metallic = 0.0f, const float &roughness = 0.0f, Texture *materialTexture = nullptr, Texture *normalTexture = nullptr,
+		MaterialDefault(const Colour &baseColor = Colour::WHITE, std::shared_ptr<Texture> diffuseTexture = nullptr,
+						const float &metallic = 0.0f, const float &roughness = 0.0f, std::shared_ptr<Texture> materialTexture = nullptr, std::shared_ptr<Texture> normalTexture = nullptr,
 						const bool &castsShadows = true, const bool &ignoreLighting = false, const bool &ignoreFog = false
 		);
 
@@ -53,9 +53,9 @@ namespace fl
 
 		void SetBaseColor(const Colour &baseColor) { *m_baseColor = baseColor; }
 
-		Texture *GetDiffuseTexture() const { return m_diffuseTexture; }
+		std::shared_ptr<Texture> GetDiffuseTexture() const { return m_diffuseTexture; }
 
-		void SetDiffuseTexture(Texture *diffuseTexture) { m_diffuseTexture = diffuseTexture; }
+		void SetDiffuseTexture(std::shared_ptr<Texture> diffuseTexture) { m_diffuseTexture = diffuseTexture; }
 
 		void TrySetDiffuseTexture(const std::string &filename)
 		{
@@ -73,9 +73,9 @@ namespace fl
 
 		void SetRoughness(const float &roughness) { m_roughness = roughness; }
 
-		Texture *GetMaterialTexture() const { return m_materialTexture; }
+		std::shared_ptr<Texture> GetMaterialTexture() const { return m_materialTexture; }
 
-		void SetMaterialTexture(Texture *materialTexture) { m_materialTexture = materialTexture; }
+		void SetMaterialTexture(std::shared_ptr<Texture> materialTexture) { m_materialTexture = materialTexture; }
 
 		void TrySetMaterialTexture(const std::string &filename)
 		{
@@ -85,9 +85,9 @@ namespace fl
 			}
 		}
 
-		Texture *GetNormalTexture() const { return m_normalTexture; }
+		std::shared_ptr<Texture> GetNormalTexture() const { return m_normalTexture; }
 
-		void SetNormalTexture(Texture *normalTexture) { m_normalTexture = normalTexture; }
+		void SetNormalTexture(std::shared_ptr<Texture> normalTexture) { m_normalTexture = normalTexture; }
 
 		void TrySetNormalTexture(const std::string &filename)
 		{
@@ -109,6 +109,6 @@ namespace fl
 
 		void SetIgnoreFog(const bool &ignoreFog) { m_ignoreFog = ignoreFog; }
 
-		PipelineMaterial *GetMaterial() const override { return m_material; }
+		std::shared_ptr<PipelineMaterial> GetMaterial() const override { return m_material; }
 	};
 }

--- a/Sources/Materials/PipelineMaterial.hpp
+++ b/Sources/Materials/PipelineMaterial.hpp
@@ -17,17 +17,17 @@ namespace fl
 		std::string m_filename;
 		Pipeline *m_pipeline;
 	public:
-		static PipelineMaterial *Resource(const GraphicsStage &graphicsStage, const PipelineCreate &pipelineCreate, const std::vector<PipelineDefine> &defines)
+		static std::shared_ptr<PipelineMaterial> Resource(const GraphicsStage &graphicsStage, const PipelineCreate &pipelineCreate, const std::vector<PipelineDefine> &defines)
 		{
-			IResource *resource = Resources::Get()->Get(ToFilename(graphicsStage, pipelineCreate, defines));
+			auto resource = Resources::Get()->Get(ToFilename(graphicsStage, pipelineCreate, defines));
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<PipelineMaterial *>(resource);
+				return std::dynamic_pointer_cast<PipelineMaterial>(resource);
 			}
 
-			PipelineMaterial *result = new PipelineMaterial(graphicsStage, pipelineCreate, defines);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<PipelineMaterial>(graphicsStage, pipelineCreate, defines);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 

--- a/Sources/Maths/Matrix2.cpp
+++ b/Sources/Maths/Matrix2.cpp
@@ -162,16 +162,6 @@ namespace fl
 		return *this;
 	}
 
-	float *Matrix2::ToArray() const
-	{
-		float *result = new float[4];
-		result[0] = m_00;
-		result[1] = m_01;
-		result[2] = m_10;
-		result[3] = m_11;
-		return result;
-	}
-
 	void Matrix2::Write(LoadedValue *destination)
 	{
 		m_0->Write(destination->GetChild("m0", true));

--- a/Sources/Maths/Matrix2.hpp
+++ b/Sources/Maths/Matrix2.hpp
@@ -141,12 +141,6 @@ namespace fl
 		Matrix2 SetIdentity();
 
 		/// <summary>
-		/// Turns this 2x2 matrix into an array.
-		/// </summary>
-		/// <returns> A 4 float array. </returns>
-		float *ToArray() const;
-
-		/// <summary>
 		/// Saves this matrix into a loaded value.
 		/// </summary>
 		/// <param name="destination"> The destination loaded value. </param>

--- a/Sources/Maths/Matrix2.hpp
+++ b/Sources/Maths/Matrix2.hpp
@@ -30,6 +30,11 @@ namespace fl
 			{
 				float m_elements[2][2];
 			};
+
+			struct
+			{
+				float m_linear[4];
+			};
 		};
 
 		static const Matrix2 IDENTITY;

--- a/Sources/Maths/Matrix3.cpp
+++ b/Sources/Maths/Matrix3.cpp
@@ -235,21 +235,6 @@ namespace fl
 		return *this;
 	}
 
-	float *Matrix3::ToArray() const
-	{
-		float *result = new float[9];
-		result[0] = m_00;
-		result[1] = m_01;
-		result[2] = m_02;
-		result[3] = m_10;
-		result[4] = m_11;
-		result[5] = m_12;
-		result[6] = m_20;
-		result[7] = m_21;
-		result[8] = m_22;
-		return result;
-	}
-
 	void Matrix3::Write(LoadedValue *destination)
 	{
 		m_0->Write(destination->GetChild("m0", true));

--- a/Sources/Maths/Matrix3.hpp
+++ b/Sources/Maths/Matrix3.hpp
@@ -143,12 +143,6 @@ namespace fl
 		Matrix3 SetIdentity();
 
 		/// <summary>
-		/// Turns this 3x3 matrix into an array.
-		/// </summary>
-		/// <returns> A 9 float array. </returns>
-		float *ToArray() const;
-
-		/// <summary>
 		/// Saves this matrix into a loaded value.
 		/// </summary>
 		/// <param name="destination"> The destination loaded value. </param>

--- a/Sources/Maths/Matrix3.hpp
+++ b/Sources/Maths/Matrix3.hpp
@@ -32,6 +32,11 @@ namespace fl
 			{
 				float m_elements[3][3];
 			};
+
+			struct
+			{
+				float m_linear[9];
+			};
 		};
 
 		static const Matrix3 IDENTITY;

--- a/Sources/Maths/Matrix4.cpp
+++ b/Sources/Maths/Matrix4.cpp
@@ -74,7 +74,6 @@ namespace fl
 	{
 	}
 
-
 	Matrix4 Matrix4::Add(const Matrix4 &other) const
 	{
 		Matrix4 result = Matrix4();

--- a/Sources/Maths/Matrix4.cpp
+++ b/Sources/Maths/Matrix4.cpp
@@ -551,28 +551,6 @@ namespace fl
 		return *this;
 	}
 
-	float *Matrix4::ToArray() const
-	{
-		float *result = new float[16];
-		result[0] = m_00;
-		result[1] = m_01;
-		result[2] = m_02;
-		result[3] = m_03;
-		result[4] = m_10;
-		result[5] = m_11;
-		result[6] = m_12;
-		result[7] = m_13;
-		result[8] = m_20;
-		result[9] = m_21;
-		result[10] = m_22;
-		result[11] = m_23;
-		result[12] = m_30;
-		result[13] = m_31;
-		result[14] = m_32;
-		result[15] = m_33;
-		return result;
-	}
-
 	void Matrix4::Write(LoadedValue *destination)
 	{
 		m_0->Write(destination->GetChild("m0", true));

--- a/Sources/Maths/Matrix4.hpp
+++ b/Sources/Maths/Matrix4.hpp
@@ -38,6 +38,11 @@ namespace fl
 			{
 				float m_elements[4][4];
 			};
+
+			struct
+			{
+				float m_linear[16];
+			};
 		};
 
 		static const Matrix4 IDENTITY;

--- a/Sources/Maths/Matrix4.hpp
+++ b/Sources/Maths/Matrix4.hpp
@@ -259,12 +259,6 @@ namespace fl
 		Matrix4 SetIdentity();
 
 		/// <summary>
-		/// Turns this 4x4 matrix into an array.
-		/// </summary>
-		/// <returns> A 16 float array. </returns>
-		float *ToArray() const;
-
-		/// <summary>
 		/// Saves this matrix into a loaded value.
 		/// </summary>
 		/// <param name="destination"> The destination loaded value. </param>

--- a/Sources/Maths/Transform.cpp
+++ b/Sources/Maths/Transform.cpp
@@ -3,70 +3,67 @@
 namespace fl
 {
 	Transform::Transform() :
-		m_position(new Vector3()),
-		m_rotation(new Vector3()),
-		m_scaling(new Vector3(1.0f, 1.0f, 1.0f))
+		m_position(Vector3()),
+		m_rotation(Vector3()),
+		m_scaling(Vector3(1.0f, 1.0f, 1.0f))
 	{
 	}
 
 	Transform::Transform(const Transform &source) :
-		m_position(new Vector3(*source.m_position)),
-		m_rotation(new Vector3(*source.m_rotation)),
-		m_scaling(new Vector3(*source.m_scaling))
+		m_position(Vector3(source.m_position)),
+		m_rotation(Vector3(source.m_rotation)),
+		m_scaling(Vector3(source.m_scaling))
 	{
 	}
 
 	Transform::Transform(const Vector3 &position, const Vector3 &rotation, const Vector3 &scaling) :
-		m_position(new Vector3(position)),
-		m_rotation(new Vector3(rotation)),
-		m_scaling(new Vector3(scaling))
+		m_position(Vector3(position)),
+		m_rotation(Vector3(rotation)),
+		m_scaling(Vector3(scaling))
 	{
 	}
 
 	Transform::Transform(const Vector3 &position, const Vector3 &rotation, const float &scale) :
-		m_position(new Vector3(position)),
-		m_rotation(new Vector3(rotation)),
-		m_scaling(new Vector3(scale, scale, scale))
+		m_position(Vector3(position)),
+		m_rotation(Vector3(rotation)),
+		m_scaling(Vector3(scale, scale, scale))
 	{
 	}
 
 	Transform::~Transform()
 	{
-		delete m_position;
-		delete m_rotation;
-		delete m_scaling;
 	}
 
 	Matrix4 Transform::GetWorldMatrix() const
 	{
-		return Matrix4::TransformationMatrix(*m_position, *m_rotation, *m_scaling);
+		return Matrix4::TransformationMatrix(m_position, m_rotation, m_scaling);
 	}
 
 	Matrix4 Transform::GetModelMatrix() const
 	{
-		return Matrix4::TransformationMatrix(Vector3(), *m_rotation, Vector3());
+		return Matrix4::TransformationMatrix(Vector3::ZERO, m_rotation, Vector3());
 	}
 
 	void Transform::Write(LoadedValue *destination)
 	{
-		m_position->Write(destination->GetChild("position", true));
-		m_rotation->Write(destination->GetChild("rotation", true));
-		m_scaling->Write(destination->GetChild("scaling", true));
+		m_position.Write(destination->GetChild("position", true));
+		m_rotation.Write(destination->GetChild("rotation", true));
+		m_scaling.Write(destination->GetChild("scaling", true));
 	}
 
 	Transform &Transform::operator=(const Transform &other)
 	{
-		*m_position = *other.m_position;
-		*m_rotation = *other.m_rotation;
-		*m_scaling = *other.m_scaling;
+		m_position = other.m_position;
+		m_rotation = other.m_rotation;
+		m_scaling = other.m_scaling;
 		return *this;
 	}
 
 	Transform &Transform::operator=(LoadedValue *value)
 	{
-		*m_position = value->GetChild("position");
-		*m_rotation = value->GetChild("rotation");
-		*m_scaling = value->GetChild("scaling");
+		m_position = value->GetChild("position");
+		m_rotation = value->GetChild("rotation");
+		m_scaling = value->GetChild("scaling");
 		return *this;
 	}
 

--- a/Sources/Maths/Transform.hpp
+++ b/Sources/Maths/Transform.hpp
@@ -12,9 +12,9 @@ namespace fl
 	class FL_EXPORT Transform
 	{
 	private:
-		Vector3 *m_position;
-		Vector3 *m_rotation;
-		Vector3 *m_scaling;
+		Vector3 m_position;
+		Vector3 m_rotation;
+		Vector3 m_scaling;
 	public:
 		/// <summary>
 		/// Constructor for Transform.
@@ -33,7 +33,7 @@ namespace fl
 		/// <param name="position"> The position. </param>
 		/// <param name="rotation"> The rotation. </param>
 		/// <param name="scaling"> The scaling. </param>
-		Transform(const Vector3 &position, const Vector3 &rotation = Vector3(), const Vector3 &scaling = Vector3(1.0f, 1.0f, 1.0f));
+		Transform(const Vector3 &position, const Vector3 &rotation = Vector3::ZERO, const Vector3 &scaling = Vector3::ONE);
 
 		/// <summary>
 		/// Constructor for Transform.
@@ -55,17 +55,17 @@ namespace fl
 		/// <param name="destination"> The destination loaded value. </param>
 		void Write(LoadedValue *destination);
 
-		Vector3 *GetPosition() const { return m_position; }
+		Vector3 GetPosition() const { return m_position; }
 
-		void SetPosition(const Vector3 &position) { *m_position = position; }
+		void SetPosition(const Vector3 &position) { m_position = position; }
 
-		Vector3 *GetRotation() const { return m_rotation; }
+		Vector3 GetRotation() const { return m_rotation; }
 
-		void SetRotation(const Vector3 &rotation) { *m_rotation = rotation; }
+		void SetRotation(const Vector3 &rotation) { m_rotation = rotation; }
 
-		Vector3 *GetScaling() const { return m_scaling; }
+		Vector3 GetScaling() const { return m_scaling; }
 
-		void SetScaling(const Vector3 &scaling) { *m_scaling = scaling; }
+		void SetScaling(const Vector3 &scaling) { m_scaling = scaling; }
 
 		Transform &operator=(const Transform &other);
 

--- a/Sources/Meshes/Mesh.cpp
+++ b/Sources/Meshes/Mesh.cpp
@@ -8,7 +8,7 @@
 
 namespace fl
 {
-	Mesh::Mesh(Model *model) :
+	Mesh::Mesh(std::shared_ptr<Model> model) :
 		Component(),
 		m_model(model)
 	{

--- a/Sources/Meshes/Mesh.hpp
+++ b/Sources/Meshes/Mesh.hpp
@@ -11,10 +11,10 @@ namespace fl
 		public Component
 	{
 	private:
-		Model *m_model;
+		std::shared_ptr<Model> m_model;
 
 	public:
-		Mesh(Model *model = nullptr);
+		Mesh(std::shared_ptr<Model> model = nullptr);
 
 		~Mesh();
 
@@ -26,9 +26,9 @@ namespace fl
 
 		std::string GetName() const override { return "Mesh"; };
 
-		virtual Model *GetModel() const { return m_model; }
+		virtual std::shared_ptr<Model> GetModel() const { return m_model; }
 
-		virtual void SetModel(Model *model) { m_model = model; }
+		virtual void SetModel(std::shared_ptr<Model> model) { m_model = model; }
 
 		virtual void TrySetModel(const std::string &filename);
 	};

--- a/Sources/Meshes/MeshRender.cpp
+++ b/Sources/Meshes/MeshRender.cpp
@@ -4,15 +4,13 @@ namespace fl
 {
 	MeshRender::MeshRender() :
 		Component(),
-		m_descriptorSet(new DescriptorsHandler()),
-		m_uniformObject(new UniformHandler())
+		m_descriptorSet(DescriptorsHandler()),
+		m_uniformObject(UniformHandler())
 	{
 	}
 
 	MeshRender::~MeshRender()
 	{
-		delete m_descriptorSet;
-		delete m_uniformObject;
 	}
 
 	void MeshRender::Update()
@@ -28,7 +26,7 @@ namespace fl
 		material->PushUniforms(m_uniformObject);
 	}
 
-	void MeshRender::CmdRender(const CommandBuffer &commandBuffer, UniformHandler *uniformScene)
+	void MeshRender::CmdRender(const CommandBuffer &commandBuffer, UniformHandler &uniformScene)
 	{
 		// Checks if the mesh is in view.
 		/*auto rigidbody = GetGameObject()->GetComponent<Rigidbody>();
@@ -54,18 +52,18 @@ namespace fl
 		material->GetMaterial()->GetPipeline()->BindPipeline(commandBuffer);
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", uniformScene);
-		m_descriptorSet->Push("UboObject", m_uniformObject);
+		m_descriptorSet.Push("UboScene", uniformScene);
+		m_descriptorSet.Push("UboObject", m_uniformObject);
 		material->PushDescriptors(m_descriptorSet);
-		bool descriptorsSet = m_descriptorSet->Update(*material->GetMaterial()->GetPipeline());
+		bool updateSuccess = m_descriptorSet.Update(*material->GetMaterial()->GetPipeline());
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}
 
 		// Draws the object.
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		mesh->GetModel()->CmdRender(commandBuffer);
 	}
 

--- a/Sources/Meshes/MeshRender.cpp
+++ b/Sources/Meshes/MeshRender.cpp
@@ -63,7 +63,7 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		mesh->GetModel()->CmdRender(commandBuffer);
 	}
 

--- a/Sources/Meshes/MeshRender.cpp
+++ b/Sources/Meshes/MeshRender.cpp
@@ -35,7 +35,7 @@ namespace fl
 
 		if (rigidbody != nullptr && rigidbody->GetCollider() != nullptr)
 		{
-			if (!rigidbody->GetCollider()->InFrustum(*Scenes::Get()->GetCamera()->GetViewFrustum()))
+			if (!rigidbody->GetCollider()->InFrustum(Scenes::Get()->GetCamera()->GetViewFrustum()))
 			{
 				return;
 			}

--- a/Sources/Meshes/MeshRender.hpp
+++ b/Sources/Meshes/MeshRender.hpp
@@ -9,8 +9,8 @@ namespace fl
 		public Component
 	{
 	private:
-		DescriptorsHandler *m_descriptorSet;
-		UniformHandler *m_uniformObject;
+		DescriptorsHandler m_descriptorSet;
+		UniformHandler m_uniformObject;
 	public:
 		MeshRender();
 
@@ -22,10 +22,10 @@ namespace fl
 
 		void Write(LoadedValue *value) override;
 
-		void CmdRender(const CommandBuffer &commandBuffer, UniformHandler *uniformScene);
+		void CmdRender(const CommandBuffer &commandBuffer, UniformHandler &uniformScene);
 
 		std::string GetName() const override { return "MeshRender"; };
 
-		UniformHandler *GetUniformObject() const { return m_uniformObject; }
+		UniformHandler GetUniformObject() const { return m_uniformObject; }
 	};
 }

--- a/Sources/Meshes/RendererMeshes.cpp
+++ b/Sources/Meshes/RendererMeshes.cpp
@@ -19,8 +19,8 @@ namespace fl
 
 	void RendererMeshes::Render(const CommandBuffer &commandBuffer, const Vector4 &clipPlane, const ICamera &camera)
 	{
-		m_uniformScene->Push("projection", *camera.GetProjectionMatrix());
-		m_uniformScene->Push("view", *camera.GetViewMatrix());
+		m_uniformScene->Push("projection", camera.GetProjectionMatrix());
+		m_uniformScene->Push("view", camera.GetViewMatrix());
 
 		std::vector<MeshRender *> renderList = std::vector<MeshRender *>();
 		Scenes::Get()->GetStructure()->QueryComponents<MeshRender>(&renderList);

--- a/Sources/Meshes/RendererMeshes.cpp
+++ b/Sources/Meshes/RendererMeshes.cpp
@@ -21,8 +21,7 @@ namespace fl
 		m_uniformScene.Push("projection", camera.GetProjectionMatrix());
 		m_uniformScene.Push("view", camera.GetViewMatrix());
 
-		std::vector<MeshRender *> renderList = std::vector<MeshRender *>();
-		Scenes::Get()->GetStructure()->QueryComponents<MeshRender>(&renderList);
+		auto renderList = Scenes::Get()->GetStructure()->QueryComponents<MeshRender>();
 
 		for (auto meshRender : renderList)
 		{

--- a/Sources/Meshes/RendererMeshes.cpp
+++ b/Sources/Meshes/RendererMeshes.cpp
@@ -8,19 +8,18 @@ namespace fl
 {
 	RendererMeshes::RendererMeshes(const GraphicsStage &graphicsStage) :
 		IRenderer(),
-		m_uniformScene(new UniformHandler(true))
+		m_uniformScene(UniformHandler(true))
 	{
 	}
 
 	RendererMeshes::~RendererMeshes()
 	{
-		delete m_uniformScene;
 	}
 
 	void RendererMeshes::Render(const CommandBuffer &commandBuffer, const Vector4 &clipPlane, const ICamera &camera)
 	{
-		m_uniformScene->Push("projection", camera.GetProjectionMatrix());
-		m_uniformScene->Push("view", camera.GetViewMatrix());
+		m_uniformScene.Push("projection", camera.GetProjectionMatrix());
+		m_uniformScene.Push("view", camera.GetViewMatrix());
 
 		std::vector<MeshRender *> renderList = std::vector<MeshRender *>();
 		Scenes::Get()->GetStructure()->QueryComponents<MeshRender>(&renderList);

--- a/Sources/Meshes/RendererMeshes.hpp
+++ b/Sources/Meshes/RendererMeshes.hpp
@@ -10,7 +10,7 @@ namespace fl
 		public IRenderer
 	{
 	private:
-		UniformHandler *m_uniformScene;
+		UniformHandler m_uniformScene;
 	public:
 		RendererMeshes(const GraphicsStage &graphicsStage);
 

--- a/Sources/Models/Model.cpp
+++ b/Sources/Models/Model.cpp
@@ -40,7 +40,7 @@ namespace fl
 			m_indexBuffer = new IndexBuffer(VK_INDEX_TYPE_UINT32, sizeof(indices[0]), indices.size(), indices.data());
 		}
 
-		m_aabb->Set(CalculateAabb(vertices));
+		*m_aabb = CalculateAabb(vertices);
 
 		for (auto vertex : vertices)
 		{
@@ -61,7 +61,7 @@ namespace fl
 
 		m_indexBuffer = new IndexBuffer(VK_INDEX_TYPE_UINT32, sizeof(indices[0]), indices.size(), indices.data());
 
-		m_aabb->Set(CalculateAabb(vertices));
+		*m_aabb = CalculateAabb(vertices);
 
 		for (auto vertex : vertices)
 		{
@@ -80,7 +80,7 @@ namespace fl
 		m_vertexBuffer = new VertexBuffer(vertices[0]->GetSize(), vertices.size(), verticesData);
 		free(verticesData);
 
-		m_aabb->Set(CalculateAabb(vertices));
+		*m_aabb = CalculateAabb(vertices);
 
 		for (auto vertex : vertices)
 		{
@@ -136,7 +136,7 @@ namespace fl
 			m_indexBuffer = new IndexBuffer(VK_INDEX_TYPE_UINT32, sizeof(indices[0]), indices.size(), indices.data());
 		}
 
-		m_aabb->Set(CalculateAabb(vertices));
+		*m_aabb = CalculateAabb(vertices);
 
 		for (auto vertex : vertices)
 		{

--- a/Sources/Models/Model.cpp
+++ b/Sources/Models/Model.cpp
@@ -147,7 +147,7 @@ namespace fl
 	void Model::LoadFromFile(const std::string &filename, std::vector<IVertex *> *vertices, std::vector<uint32_t> *indices)
 	{
 #if FL_VERBOSE
-		const auto debugStart = Engine::Get()->GetTimeMs();
+		float debugStart = Engine::Get()->GetTimeMs();
 #endif
 
 		delete m_indexBuffer;
@@ -161,20 +161,20 @@ namespace fl
 		}
 
 		const std::string fileLoaded = FileSystem::ReadTextFile(m_filename);
-		std::vector<std::string> lines = FormatString::Split(fileLoaded, "\n");
+		auto lines = FormatString::Split(fileLoaded, "\n");
 
-		std::vector<uint32_t> indicesList = std::vector<uint32_t>();
-		std::vector<VertexModelData *> verticesList = std::vector<VertexModelData *>();
-		std::vector<Vector2> uvsList = std::vector<Vector2>();
-		std::vector<Vector3> normalsList = std::vector<Vector3>();
+		auto indicesList = std::vector<uint32_t>();
+		auto verticesList = std::vector<VertexModelData *>();
+		auto uvsList = std::vector<Vector2>();
+		auto normalsList = std::vector<Vector3>();
 
 		for (auto line : lines)
 		{
-			std::vector<std::string> split = FormatString::Split(line, " ", true);
+			auto split = FormatString::Split(line, " ", true);
 
 			if (!split.empty())
 			{
-				const std::string prefix = split[0];
+				std::string prefix = split[0];
 
 				if (prefix == "#")
 				{
@@ -182,19 +182,19 @@ namespace fl
 				}
 				else if (prefix == "v")
 				{
-					const Vector3 vertex = Vector3(std::stof(split[1]), std::stof(split[2]), std::stof(split[3]));
+					Vector3 vertex = Vector3(std::stof(split[1]), std::stof(split[2]), std::stof(split[3]));
 					VertexModelData *newVertex = new VertexModelData(static_cast<int>(verticesList.size()), vertex);
-					verticesList.push_back(newVertex);
+					verticesList.emplace_back(newVertex);
 				}
 				else if (prefix == "vt")
 				{
-					const Vector2 uv = Vector2(std::stof(split[1]), 1.0f - std::stof(split[2]));
-					uvsList.push_back(uv);
+					Vector2 uv = Vector2(std::stof(split[1]), 1.0f - std::stof(split[2]));
+					uvsList.emplace_back(uv);
 				}
 				else if (prefix == "vn")
 				{
-					const Vector3 normal = Vector3(std::stof(split[1]), std::stof(split[2]), std::stof(split[3]));
-					normalsList.push_back(normal);
+					Vector3 normal = Vector3(std::stof(split[1]), std::stof(split[2]), std::stof(split[3]));
+					normalsList.emplace_back(normal);
 				}
 				else if (prefix == "f")
 				{
@@ -205,9 +205,9 @@ namespace fl
 						throw std::runtime_error("Model loading error.");
 					}
 
-					std::vector<std::string> vertex1 = FormatString::Split(split[1], "/");
-					std::vector<std::string> vertex2 = FormatString::Split(split[2], "/");
-					std::vector<std::string> vertex3 = FormatString::Split(split[3], "/");
+					auto vertex1 = FormatString::Split(split[1], "/");
+					auto vertex2 = FormatString::Split(split[2], "/");
+					auto vertex3 = FormatString::Split(split[3], "/");
 
 					VertexModelData *v0 = ProcessDataVertex(Vector3(std::stof(vertex1[0]), std::stof(vertex1[1]), std::stof(vertex1[2])), &verticesList, &indicesList);
 					VertexModelData *v1 = ProcessDataVertex(Vector3(std::stof(vertex2[0]), std::stof(vertex2[1]), std::stof(vertex2[2])), &verticesList, &indicesList);
@@ -244,18 +244,18 @@ namespace fl
 		// Turns the loaded data into a format that can be used by OpenGL.
 		for (auto current : verticesList)
 		{
-			const Vector3 position = current->GetPosition();
-			const Vector2 textures = uvsList[current->GetUvIndex()];
-			const Vector3 normal = normalsList[current->GetNormalIndex()];
-			const Vector3 tangent = current->GetAverageTangent();
+			Vector3 position = current->GetPosition();
+			Vector2 textures = uvsList[current->GetUvIndex()];
+			Vector3 normal = normalsList[current->GetNormalIndex()];
+			Vector3 tangent = current->GetAverageTangent();
 
-			vertices->push_back(new VertexModel(position, textures, normal, tangent));
+			vertices->emplace_back(new VertexModel(position, textures, normal, tangent));
 
 			delete current;
 		}
 
 #if FL_VERBOSE
-		const auto debugEnd = Engine::Get()->GetTimeMs();
+		float debugEnd = Engine::Get()->GetTimeMs();
 		printf("Obj '%s' loaded in %fms\n", m_filename.c_str(), debugEnd - debugStart);
 #endif
 
@@ -264,16 +264,16 @@ namespace fl
 
 	VertexModelData *Model::ProcessDataVertex(const Vector3 &vertex, std::vector<VertexModelData *> *vertices, std::vector<uint32_t> *indices)
 	{
-		const int index = static_cast<int>(vertex.m_x) - 1;
-		const int textureIndex = static_cast<int>(vertex.m_y) - 1;
-		const int normalIndex = static_cast<int>(vertex.m_z) - 1;
+		int index = static_cast<int>(vertex.m_x) - 1;
+		int textureIndex = static_cast<int>(vertex.m_y) - 1;
+		int normalIndex = static_cast<int>(vertex.m_z) - 1;
 		VertexModelData *currentVertex = (*vertices)[index];
 
 		if (!currentVertex->IsSet())
 		{
 			currentVertex->SetUvIndex(textureIndex);
 			currentVertex->SetNormalIndex(normalIndex);
-			indices->push_back(index);
+			indices->emplace_back(index);
 			return currentVertex;
 		}
 
@@ -284,7 +284,7 @@ namespace fl
 	{
 		if (previousVertex->HasSameTextureAndNormal(newTextureIndex, newNormalIndex))
 		{
-			indices->push_back(previousVertex->GetIndex());
+			indices->emplace_back(previousVertex->GetIndex());
 			return previousVertex;
 		}
 
@@ -299,8 +299,8 @@ namespace fl
 		duplicateVertex->SetUvIndex(newTextureIndex);
 		duplicateVertex->SetNormalIndex(newNormalIndex);
 		previousVertex->SetDuplicateVertex(duplicateVertex);
-		vertices->push_back(duplicateVertex);
-		indices->push_back(duplicateVertex->GetIndex());
+		vertices->emplace_back(duplicateVertex);
+		indices->emplace_back(duplicateVertex->GetIndex());
 		return duplicateVertex;
 	}
 

--- a/Sources/Models/Model.hpp
+++ b/Sources/Models/Model.hpp
@@ -27,17 +27,17 @@ namespace fl
 		ColliderAabb *m_aabb;
 
 	public:
-		static Model *Resource(const std::string &filename)
+		static std::shared_ptr<Model> Resource(const std::string &filename)
 		{
-			IResource *resource = Resources::Get()->Get(filename);
+			auto resource = Resources::Get()->Get(filename);
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<Model *>(resource);
+				return std::dynamic_pointer_cast<Model>(resource);
 			}
 
-			Model *result = new Model(filename);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<Model>(filename);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 

--- a/Sources/Models/Model.hpp
+++ b/Sources/Models/Model.hpp
@@ -25,7 +25,6 @@ namespace fl
 		IndexBuffer *m_indexBuffer;
 
 		ColliderAabb *m_aabb;
-
 	public:
 		static std::shared_ptr<Model> Resource(const std::string &filename)
 		{

--- a/Sources/Models/Shapes/MeshPattern.cpp
+++ b/Sources/Models/Shapes/MeshPattern.cpp
@@ -13,8 +13,8 @@ namespace fl
 
 	void MeshPattern::GenerateMesh()
 	{
-		std::vector<IVertex *> vertices = std::vector<IVertex *>();
-		std::vector<uint32_t> indices = std::vector<uint32_t>();
+		auto vertices = std::vector<IVertex *>();
+		auto indices = std::vector<uint32_t>();
 
 		// Creates and stores vertices.
 		for (int col = 0; col < m_vertexCount; col++)
@@ -22,16 +22,16 @@ namespace fl
 			for (int row = 0; row < m_vertexCount; row++)
 			{
 				// Creates and stores vertices.
-				const Vector3 position = GetPosition(
+				Vector3 position = GetPosition(
 					((row * m_squareSize) - m_sideLength) / 2.0f,
 					((col * m_squareSize) - m_sideLength) / 2.0f
 				);
-				const Vector2 uv = Vector2(
+				Vector2 uv = Vector2(
 					m_textureScale * static_cast<float>(col) / static_cast<float>(m_vertexCount),
 					m_textureScale * static_cast<float>(row) / static_cast<float>(m_vertexCount)
 				);
-				const Vector3 normal = GetNormal(position);
-				const Vector3 tangent = GetColour(position, normal);
+				Vector3 normal = GetNormal(position);
+				Vector3 tangent = GetColour(position, normal);
 				vertices.push_back(new VertexModel(position, uv, normal, tangent));
 			}
 		}
@@ -41,11 +41,11 @@ namespace fl
 		{
 			for (int row = 0; row < m_vertexCount - 1; row++)
 			{
-				const uint32_t topLeft = (row * m_vertexCount) + col;
-				const uint32_t topRight = topLeft + 1;
-				const uint32_t bottomLeft = ((row + 1) * m_vertexCount) + col;
-				const uint32_t bottomRight = bottomLeft + 1;
-				const bool mixed = col % 2 == 0;
+				uint32_t topLeft = (row * m_vertexCount) + col;
+				uint32_t topRight = topLeft + 1;
+				uint32_t bottomLeft = ((row + 1) * m_vertexCount) + col;
+				uint32_t bottomRight = bottomLeft + 1;
+				bool mixed = col % 2 == 0;
 
 				if (row % 2 == 0)
 				{

--- a/Sources/Models/Shapes/MeshPattern.cpp
+++ b/Sources/Models/Shapes/MeshPattern.cpp
@@ -32,7 +32,7 @@ namespace fl
 				);
 				Vector3 normal = GetNormal(position);
 				Vector3 tangent = GetColour(position, normal);
-				vertices.push_back(new VertexModel(position, uv, normal, tangent));
+				vertices.emplace_back(new VertexModel(position, uv, normal, tangent));
 			}
 		}
 
@@ -49,21 +49,21 @@ namespace fl
 
 				if (row % 2 == 0)
 				{
-					indices.push_back(topLeft);
-					indices.push_back(bottomLeft);
-					indices.push_back(mixed ? topRight : bottomRight);
-					indices.push_back(bottomRight);
-					indices.push_back(topRight);
-					indices.push_back(mixed ? bottomLeft : topLeft);
+					indices.emplace_back(topLeft);
+					indices.emplace_back(bottomLeft);
+					indices.emplace_back(mixed ? topRight : bottomRight);
+					indices.emplace_back(bottomRight);
+					indices.emplace_back(topRight);
+					indices.emplace_back(mixed ? bottomLeft : topLeft);
 				}
 				else
 				{
-					indices.push_back(topRight);
-					indices.push_back(topLeft);
-					indices.push_back(mixed ? bottomRight : bottomLeft);
-					indices.push_back(bottomLeft);
-					indices.push_back(bottomRight);
-					indices.push_back(mixed ? topLeft : topRight);
+					indices.emplace_back(topRight);
+					indices.emplace_back(topLeft);
+					indices.emplace_back(mixed ? bottomRight : bottomLeft);
+					indices.emplace_back(bottomLeft);
+					indices.emplace_back(bottomRight);
+					indices.emplace_back(mixed ? topLeft : topRight);
 				}
 			}
 		}

--- a/Sources/Models/Shapes/MeshSimple.cpp
+++ b/Sources/Models/Shapes/MeshSimple.cpp
@@ -32,7 +32,7 @@ namespace fl
 				);
 				Vector3 normal = GetNormal(position);
 				Vector3 tangent = GetColour(position, normal);
-				vertices.push_back(new VertexModel(position, uv, normal, tangent));
+				vertices.emplace_back(new VertexModel(position, uv, normal, tangent));
 			}
 		}
 
@@ -46,12 +46,12 @@ namespace fl
 				uint32_t bottomLeft = ((row + 1) * m_vertexCount) + col;
 				uint32_t bottomRight = bottomLeft + 1;
 
-				indices.push_back(topLeft);
-				indices.push_back(bottomLeft);
-				indices.push_back(topRight);
-				indices.push_back(topRight);
-				indices.push_back(bottomLeft);
-				indices.push_back(bottomRight);
+				indices.emplace_back(topLeft);
+				indices.emplace_back(bottomLeft);
+				indices.emplace_back(topRight);
+				indices.emplace_back(topRight);
+				indices.emplace_back(bottomLeft);
+				indices.emplace_back(bottomRight);
 			}
 		}
 

--- a/Sources/Models/Shapes/MeshSimple.cpp
+++ b/Sources/Models/Shapes/MeshSimple.cpp
@@ -13,8 +13,8 @@ namespace fl
 
 	void MeshSimple::GenerateMesh()
 	{
-		std::vector<IVertex *> vertices = std::vector<IVertex *>();
-		std::vector<uint32_t> indices = std::vector<uint32_t>();
+		auto vertices = std::vector<IVertex *>();
+		auto indices = std::vector<uint32_t>();
 
 		// Creates and stores vertices.
 		for (int col = 0; col < m_vertexCount; col++)
@@ -22,16 +22,16 @@ namespace fl
 			for (int row = 0; row < m_vertexCount; row++)
 			{
 				// Creates and stores vertices.
-				const Vector3 position = GetPosition(
+				Vector3 position = GetPosition(
 					((row * m_squareSize) - m_sideLength) / 2.0f,
 					((col * m_squareSize) - m_sideLength) / 2.0f
 				);
-				const Vector2 uv = Vector2(
+				Vector2 uv = Vector2(
 					m_textureScale * static_cast<float>(col) / static_cast<float>(m_vertexCount),
 					m_textureScale * static_cast<float>(row) / static_cast<float>(m_vertexCount)
 				);
-				const Vector3 normal = GetNormal(position);
-				const Vector3 tangent = GetColour(position, normal);
+				Vector3 normal = GetNormal(position);
+				Vector3 tangent = GetColour(position, normal);
 				vertices.push_back(new VertexModel(position, uv, normal, tangent));
 			}
 		}
@@ -41,17 +41,11 @@ namespace fl
 		{
 			for (int row = 0; row < m_vertexCount - 1; row++)
 			{
-				const uint32_t topLeft = (row * m_vertexCount) + col;
-				const uint32_t topRight = topLeft + 1;
-				const uint32_t bottomLeft = ((row + 1) * m_vertexCount) + col;
-				const uint32_t bottomRight = bottomLeft + 1;
+				uint32_t topLeft = (row * m_vertexCount) + col;
+				uint32_t topRight = topLeft + 1;
+				uint32_t bottomLeft = ((row + 1) * m_vertexCount) + col;
+				uint32_t bottomRight = bottomLeft + 1;
 
-				//	indices.push_back(topLeft);
-				//	indices.push_back(bottomLeft);
-				//	indices.push_back(bottomRight);
-				//	indices.push_back(topLeft);
-				//	indices.push_back(bottomRight);
-				//	indices.push_back(topRight);
 				indices.push_back(topLeft);
 				indices.push_back(bottomLeft);
 				indices.push_back(topRight);

--- a/Sources/Models/Shapes/ShapeCube.hpp
+++ b/Sources/Models/Shapes/ShapeCube.hpp
@@ -10,21 +10,21 @@ namespace fl
 		public Model
 	{
 	public:
-		static ShapeCube *Resource(const float &width, const float &height, const float &depth)
+		static std::shared_ptr<ShapeCube> Resource(const float &width, const float &height, const float &depth)
 		{
-			IResource *resource = Resources::Get()->Get(ToFilename(width, height, depth));
+			auto resource = Resources::Get()->Get(ToFilename(width, height, depth));
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<ShapeCube *>(resource);
+				return std::dynamic_pointer_cast<ShapeCube>(resource);
 			}
 
-			ShapeCube *result = new ShapeCube(width, height, depth);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<ShapeCube>(width, height, depth);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 
-		static ShapeCube *Resource(const std::string &filename)
+		static std::shared_ptr<ShapeCube> Resource(const std::string &filename)
 		{
 			auto split = FormatString::Split(filename, "_");
 			float width = static_cast<float>(atof(split[1].c_str()));

--- a/Sources/Models/Shapes/ShapeCylinder.cpp
+++ b/Sources/Models/Shapes/ShapeCylinder.cpp
@@ -7,8 +7,8 @@ namespace fl
 	ShapeCylinder::ShapeCylinder(const float &radiusBase, const float &radiusTop, const float &height, const unsigned int &slices, const unsigned int &stacks, const float &y0) :
 		Model()
 	{
-		std::vector<IVertex *> vertices = std::vector<IVertex *>();
-		std::vector<uint32_t> indices = std::vector<uint32_t>();
+		auto vertices = std::vector<IVertex *>();
+		auto indices = std::vector<uint32_t>();
 
 		for (unsigned int i = 0; i < slices + 1; i++)
 		{

--- a/Sources/Models/Shapes/ShapeCylinder.cpp
+++ b/Sources/Models/Shapes/ShapeCylinder.cpp
@@ -32,7 +32,7 @@ namespace fl
 				vertex->m_normal.m_y = 0.0f;
 				vertex->m_normal.m_z = zDir;
 
-				vertices.push_back(vertex);
+				vertices.emplace_back(vertex);
 			}
 		}
 
@@ -43,13 +43,13 @@ namespace fl
 				uint32_t first = j + ((stacks + 1) * i);
 				uint32_t second = j + ((stacks + 1) * (i + 1));
 
-				indices.push_back(first);
-				indices.push_back(second);
-				indices.push_back(second + 1);
+				indices.emplace_back(first);
+				indices.emplace_back(second);
+				indices.emplace_back(second + 1);
 
-				indices.push_back(first);
-				indices.push_back(second + 1);
-				indices.push_back(first + 1);
+				indices.emplace_back(first);
+				indices.emplace_back(second + 1);
+				indices.emplace_back(first + 1);
 			}
 		}
 

--- a/Sources/Models/Shapes/ShapeCylinder.hpp
+++ b/Sources/Models/Shapes/ShapeCylinder.hpp
@@ -10,21 +10,21 @@ namespace fl
 		public Model
 	{
 	public:
-		static ShapeCylinder *Resource(const float &radiusBase, const float &radiusTop, const float &height, const unsigned int &slices, const unsigned int &stacks, const float &y0)
+		static std::shared_ptr<ShapeCylinder> Resource(const float &radiusBase, const float &radiusTop, const float &height, const unsigned int &slices, const unsigned int &stacks, const float &y0)
 		{
-			IResource *resource = Resources::Get()->Get(ToFilename(radiusBase, radiusTop, height, slices, stacks, y0));
+			auto resource = Resources::Get()->Get(ToFilename(radiusBase, radiusTop, height, slices, stacks, y0));
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<ShapeCylinder *>(resource);
+				return std::dynamic_pointer_cast<ShapeCylinder>(resource);
 			}
 
-			ShapeCylinder *result = new ShapeCylinder(radiusBase, radiusTop, height, slices, stacks, y0);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<ShapeCylinder>(radiusBase, radiusTop, height, slices, stacks, y0);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 
-		static ShapeCylinder *Resource(const std::string &filename)
+		static std::shared_ptr<ShapeCylinder> Resource(const std::string &filename)
 		{
 			auto split = FormatString::Split(filename, "_");
 			float radiusBase = static_cast<float>(atof(split[1].c_str()));

--- a/Sources/Models/Shapes/ShapeDisk.cpp
+++ b/Sources/Models/Shapes/ShapeDisk.cpp
@@ -18,8 +18,8 @@ namespace fl
 
 			for (unsigned int j = 0; j < loops + 1; j++)
 			{
-				const float jDivLoops = static_cast<float>(j) / static_cast<float>(loops);
-				const float radius = innerRadius + jDivLoops * (outerRadius - innerRadius);
+				float jDivLoops = static_cast<float>(j) / static_cast<float>(loops);
+				float radius = innerRadius + jDivLoops * (outerRadius - innerRadius);
 
 				VertexModel *vertex = new VertexModel();
 				vertex->m_normal.m_x = 0.0f;

--- a/Sources/Models/Shapes/ShapeDisk.cpp
+++ b/Sources/Models/Shapes/ShapeDisk.cpp
@@ -31,7 +31,7 @@ namespace fl
 				vertex->m_position.m_y = 0.0f;
 				vertex->m_position.m_z = radius * yDir;
 
-				vertices.push_back(vertex);
+				vertices.emplace_back(vertex);
 			}
 		}
 
@@ -42,13 +42,13 @@ namespace fl
 				uint32_t first = i * (loops + 1) + j;
 				uint32_t second = (first + loops + 1) % (slices * (loops + 1));
 
-				indices.push_back(first);
-				indices.push_back(second + 1);
-				indices.push_back(second);
+				indices.emplace_back(first);
+				indices.emplace_back(second + 1);
+				indices.emplace_back(second);
 
-				indices.push_back(first);
-				indices.push_back(first + 1);
-				indices.push_back(second + 1);
+				indices.emplace_back(first);
+				indices.emplace_back(first + 1);
+				indices.emplace_back(second + 1);
 			}
 		}
 

--- a/Sources/Models/Shapes/ShapeDisk.hpp
+++ b/Sources/Models/Shapes/ShapeDisk.hpp
@@ -10,21 +10,21 @@ namespace fl
 		public Model
 	{
 	public:
-		static ShapeDisk *Resource(const float &innerRadius, const float &outerRadius, const unsigned int &slices, const unsigned int &loops)
+		static std::shared_ptr<ShapeDisk> Resource(const float &innerRadius, const float &outerRadius, const unsigned int &slices, const unsigned int &loops)
 		{
-			IResource *resource = Resources::Get()->Get(ToFilename(innerRadius, outerRadius, slices, loops));
+			auto resource = Resources::Get()->Get(ToFilename(innerRadius, outerRadius, slices, loops));
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<ShapeDisk *>(resource);
+				return std::dynamic_pointer_cast<ShapeDisk>(resource);
 			}
 
-			ShapeDisk *result = new ShapeDisk(innerRadius, outerRadius, slices, loops);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<ShapeDisk>(innerRadius, outerRadius, slices, loops);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 
-		static ShapeDisk *Resource(const std::string &filename)
+		static std::shared_ptr<ShapeDisk> Resource(const std::string &filename)
 		{
 			auto split = FormatString::Split(filename, "_");
 			float innerRadius = static_cast<float>(atof(split[1].c_str()));

--- a/Sources/Models/Shapes/ShapeRectangle.hpp
+++ b/Sources/Models/Shapes/ShapeRectangle.hpp
@@ -9,21 +9,21 @@ namespace fl
 		public Model
 	{
 	public:
-		static ShapeRectangle *Resource(const float &min, const float &max)
+		static std::shared_ptr<ShapeRectangle> Resource(const float &min, const float &max)
 		{
-			IResource *resource = Resources::Get()->Get(ToFilename(min, max));
+			auto resource = Resources::Get()->Get(ToFilename(min, max));
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<ShapeRectangle *>(resource);
+				return std::dynamic_pointer_cast<ShapeRectangle>(resource);
 			}
 
-			ShapeRectangle *result = new ShapeRectangle(min, max);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<ShapeRectangle>(min, max);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 
-		static ShapeRectangle *Resource(const std::string &filename)
+		static std::shared_ptr<ShapeRectangle> Resource(const std::string &filename)
 		{
 			auto split = FormatString::Split(filename, "_");
 			float width = static_cast<float>(atof(split[1].c_str()));

--- a/Sources/Models/Shapes/ShapeSphere.cpp
+++ b/Sources/Models/Shapes/ShapeSphere.cpp
@@ -30,7 +30,7 @@ namespace fl
 				vertex->m_position.m_y = radius * vertex->m_normal.m_y;
 				vertex->m_position.m_z = radius * vertex->m_normal.m_z;
 
-				vertices.push_back(vertex);
+				vertices.emplace_back(vertex);
 			}
 		}
 
@@ -41,13 +41,13 @@ namespace fl
 				uint32_t first = j + ((latitudeBands + 1) * i);
 				uint32_t second = j + ((latitudeBands + 1) * (i + 1));
 
-				indices.push_back(first);
-				indices.push_back(second + 1);
-				indices.push_back(second);
+				indices.emplace_back(first);
+				indices.emplace_back(second + 1);
+				indices.emplace_back(second);
 
-				indices.push_back(first);
-				indices.push_back(first + 1);
-				indices.push_back(second + 1);
+				indices.emplace_back(first);
+				indices.emplace_back(first + 1);
+				indices.emplace_back(second + 1);
 			}
 		}
 

--- a/Sources/Models/Shapes/ShapeSphere.hpp
+++ b/Sources/Models/Shapes/ShapeSphere.hpp
@@ -10,21 +10,21 @@ namespace fl
 		public Model
 	{
 	public:
-		static ShapeSphere *Resource(const unsigned int &latitudeBands, const unsigned int &longitudeBands, const float &radius)
+		static std::shared_ptr<ShapeSphere> Resource(const unsigned int &latitudeBands, const unsigned int &longitudeBands, const float &radius)
 		{
-			IResource *resource = Resources::Get()->Get(ToFilename(latitudeBands, longitudeBands, radius));
+			auto resource = Resources::Get()->Get(ToFilename(latitudeBands, longitudeBands, radius));
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<ShapeSphere *>(resource);
+				return std::dynamic_pointer_cast<ShapeSphere>(resource);
 			}
 
-			ShapeSphere *result = new ShapeSphere(latitudeBands, longitudeBands, radius);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<ShapeSphere>(latitudeBands, longitudeBands, radius);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 
-		static ShapeSphere *Resource(const std::string &filename)
+		static std::shared_ptr<ShapeSphere> Resource(const std::string &filename)
 		{
 			auto split = FormatString::Split(filename, "_");
 			int latitudeBands = atoi(split[1].c_str());

--- a/Sources/Models/VertexModel.cpp
+++ b/Sources/Models/VertexModel.cpp
@@ -33,7 +33,7 @@ namespace fl
 
 		for (auto vertex : vertices)
 		{
-			thisVector.push_back(*((VertexModel *) vertex));
+			thisVector.emplace_back(*((VertexModel *) vertex));
 		}
 
 		memcpy(data, thisVector.data(), dataSize);

--- a/Sources/Models/VertexModel.hpp
+++ b/Sources/Models/VertexModel.hpp
@@ -17,7 +17,7 @@ namespace fl
 		Vector3 m_normal;
 		Vector3 m_tangent;
 
-		VertexModel(const Vector3 &position = Vector3(), const Vector2 &uv = Vector2(), const Vector3 &normal = Vector3(), const Vector3 &tangent = Vector3());
+		VertexModel(const Vector3 &position = Vector3::ZERO, const Vector2 &uv = Vector2::ZERO, const Vector3 &normal = Vector3::ZERO, const Vector3 &tangent = Vector3::ZERO);
 
 		VertexModel(const VertexModel &source);
 

--- a/Sources/Models/VertexModelData.cpp
+++ b/Sources/Models/VertexModelData.cpp
@@ -23,7 +23,7 @@ namespace fl
 
 	void VertexModelData::AddTangent(Vector3 *tangent)
 	{
-		m_tangents.push_back(tangent);
+		m_tangents.emplace_back(tangent);
 	}
 
 	void VertexModelData::AverageTangents()

--- a/Sources/Objects/ComponentRegister.cpp
+++ b/Sources/Objects/ComponentRegister.cpp
@@ -14,7 +14,7 @@
 namespace fl
 {
 	ComponentRegister::ComponentRegister() :
-		m_components(new std::map<std::string, ComponentCreate *>())
+		m_components(std::map<std::string, ComponentCreate>())
 	{
 		RegisterComponent<CelestialBody>("CelestialBody");
 		RegisterComponent<ColliderAabb>("AabbCollider");
@@ -32,46 +32,42 @@ namespace fl
 
 	ComponentRegister::~ComponentRegister()
 	{
-		for (auto it = --m_components->end(); it != m_components->begin(); --it)
-		{
-			delete (*it).second;
-		}
-
-		delete m_components;
 	}
 
-	ComponentRegister::ComponentCreate *ComponentRegister::GetComponent(const std::string &name)
+	ComponentRegister::ComponentCreate ComponentRegister::GetComponentCreate(const std::string &name)
 	{
-		for (auto &component : *m_components)
+		auto component = m_components.find(name);
+
+		if (component == m_components.end())
 		{
-			if (component.first == name)
-			{
-				return component.second;
-			}
+			return nullptr;
 		}
 
-		return nullptr;
+		return (*component).second;
 	}
 
 	void ComponentRegister::DeregisterComponent(const std::string &name)
 	{
-		for (auto it = --m_components->end(); it != m_components->begin(); --it)
+		auto component = m_components.find(name);
+
+		if (component == m_components.end())
 		{
-			m_components->erase(it);
-			delete (*it).second;
+			return;
 		}
+
+		m_components.erase(component);
 	}
 
-	Component *ComponentRegister::CreateComponent(const std::string &name)
+	std::shared_ptr<Component> ComponentRegister::CreateComponent(const std::string &name)
 	{
-		auto found = m_components->find(name);
+		auto found = m_components.find(name);
 
-		if (found == m_components->end())
+		if (found == m_components.end())
 		{
 			fprintf(stderr, "Could not find registered component: '%s'\n", name.c_str());
 			return nullptr;
 		}
 
-		return (*(*found).second)();
+		return ((*found).second)();
 	}
 }

--- a/Sources/Objects/ComponentRegister.hpp
+++ b/Sources/Objects/ComponentRegister.hpp
@@ -39,8 +39,10 @@ namespace fl
 				return;
 			}
 
-			m_components->insert(std::make_pair(name, new ComponentCreate([]() -> Component *
-			{ return static_cast<Component *>(new T()); })));
+			m_components->emplace(name, new ComponentCreate([]() -> Component *
+			{
+				return static_cast<Component *>(new T());
+			}));
 		}
 
 		/// <summary>

--- a/Sources/Objects/ComponentRegister.hpp
+++ b/Sources/Objects/ComponentRegister.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include "Component.hpp"
 
 namespace fl
@@ -10,9 +11,9 @@ namespace fl
 	class FL_EXPORT ComponentRegister
 	{
 	private:
-		typedef std::function<Component *()> ComponentCreate;
+		typedef std::function<std::shared_ptr<Component>()> ComponentCreate;
 
-		std::map<std::string, ComponentCreate *> *m_components;
+		std::map<std::string, ComponentCreate> m_components;
 	public:
 		/// <summary>
 		/// Creates a new component register.
@@ -33,15 +34,15 @@ namespace fl
 		template<typename T>
 		void RegisterComponent(const std::string &name)
 		{
-			if (m_components->find(name) != m_components->end())
+			if (m_components.find(name) != m_components.end())
 			{
 				fprintf(stderr, "Component '%s' is already registered!\n", name.c_str());
 				return;
 			}
 
-			m_components->emplace(name, new ComponentCreate([]() -> Component *
+			m_components.emplace(name, ComponentCreate([]() -> std::shared_ptr<Component>
 			{
-				return static_cast<Component *>(new T());
+				return std::dynamic_pointer_cast<Component>(std::make_shared<T>());
 			}));
 		}
 
@@ -56,13 +57,13 @@ namespace fl
 		/// </summary>
 		/// <param name="name"> The component name to get. </param>
 		/// <returns> The component create object. </returns>
-		ComponentCreate *GetComponent(const std::string &name);
+		ComponentCreate GetComponentCreate(const std::string &name);
 
 		/// <summary>
 		/// Creates a new component from the register.
 		/// </summary>
 		/// <param name="name"> The component name to create. </param>
 		/// <returns> The new component. </returns>
-		Component *CreateComponent(const std::string &name);
+		std::shared_ptr<Component> CreateComponent(const std::string &name);
 	};
 }

--- a/Sources/Objects/GameObject.cpp
+++ b/Sources/Objects/GameObject.cpp
@@ -27,7 +27,7 @@ namespace fl
 	GameObject::GameObject(const std::string &prefabName, const Transform &transform, ISpatialStructure *structure) :
 		GameObject(transform, structure, prefabName)
 	{
-		PrefabObject *prefabObject = PrefabObject::Resource("Resources/Objects/" + prefabName + "/" + prefabName + ".json");
+		auto prefabObject = PrefabObject::Resource("Resources/Objects/" + prefabName + "/" + prefabName + ".json");
 
 		for (auto value : *prefabObject->GetParent()->GetChildren())
 		{

--- a/Sources/Objects/GameObject.cpp
+++ b/Sources/Objects/GameObject.cpp
@@ -8,7 +8,7 @@ namespace fl
 	GameObject::GameObject(const Transform &transform, ISpatialStructure *structure) :
 		m_name(""),
 		m_transform(new Transform(transform)),
-		m_components(std::vector<Component *>()),
+		m_components(std::vector<std::shared_ptr<Component>>()),
 		m_structure(structure),
 		m_parent(nullptr),
 		m_removed(false)
@@ -36,7 +36,7 @@ namespace fl
 				continue;
 			}
 
-			Component *component = Scenes::Get()->CreateComponent(value->GetName());
+			auto component = Scenes::Get()->CreateComponent(value->GetName());
 
 			if (component == nullptr)
 			{
@@ -53,12 +53,6 @@ namespace fl
 	GameObject::~GameObject()
 	{
 		StructureRemove();
-
-		for (auto component : m_components)
-		{
-			delete component;
-		}
-
 		delete m_transform;
 	}
 
@@ -83,7 +77,7 @@ namespace fl
 		}
 	}
 
-	Component *GameObject::AddComponent(Component *component)
+	std::shared_ptr<Component> GameObject::AddComponent(std::shared_ptr<Component> component)
 	{
 		if (component == nullptr)
 		{
@@ -95,7 +89,7 @@ namespace fl
 		return component;
 	}
 
-	Component *GameObject::RemoveComponent(Component *component)
+	std::shared_ptr<Component> GameObject::RemoveComponent(std::shared_ptr<Component> component)
 	{
 		for (auto it = m_components.begin(); it != m_components.end(); ++it)
 		{
@@ -106,7 +100,6 @@ namespace fl
 					(*it)->SetGameObject(nullptr);
 				}
 
-				delete component;
 				m_components.erase(it);
 				return *it;
 			}

--- a/Sources/Objects/GameObject.cpp
+++ b/Sources/Objects/GameObject.cpp
@@ -5,8 +5,8 @@
 
 namespace fl
 {
-	GameObject::GameObject(const Transform &transform, ISpatialStructure *structure, const std::string &name) :
-		m_name(name),
+	GameObject::GameObject(const Transform &transform, ISpatialStructure *structure) :
+		m_name(""),
 		m_transform(new Transform(transform)),
 		m_components(std::vector<Component *>()),
 		m_structure(structure),
@@ -25,7 +25,7 @@ namespace fl
 	}
 
 	GameObject::GameObject(const std::string &prefabName, const Transform &transform, ISpatialStructure *structure) :
-		GameObject(transform, structure, prefabName)
+		GameObject(transform, structure)
 	{
 		auto prefabObject = PrefabObject::Resource("Resources/Objects/" + prefabName + "/" + prefabName + ".json");
 
@@ -46,6 +46,8 @@ namespace fl
 			component->Load(value);
 			AddComponent(component);
 		}
+
+		m_name = prefabName;
 	}
 
 	GameObject::~GameObject()

--- a/Sources/Objects/GameObject.cpp
+++ b/Sources/Objects/GameObject.cpp
@@ -89,7 +89,7 @@ namespace fl
 		}
 
 		component->SetGameObject(this);
-		m_components.push_back(component);
+		m_components.emplace_back(component);
 		return component;
 	}
 

--- a/Sources/Objects/GameObject.cpp
+++ b/Sources/Objects/GameObject.cpp
@@ -8,7 +8,7 @@ namespace fl
 	GameObject::GameObject(const Transform &transform, ISpatialStructure *structure, const std::string &name) :
 		m_name(name),
 		m_transform(new Transform(transform)),
-		m_components(new std::vector<Component *>()),
+		m_components(std::vector<Component *>()),
 		m_structure(structure),
 		m_parent(nullptr),
 		m_removed(false)
@@ -52,12 +52,11 @@ namespace fl
 	{
 		StructureRemove();
 
-		for (auto component : *m_components)
+		for (auto component : m_components)
 		{
 			delete component;
 		}
 
-		delete m_components;
 		delete m_transform;
 	}
 
@@ -68,7 +67,7 @@ namespace fl
 			return;
 		}
 
-		for (auto it = m_components->begin(); it != m_components->end(); ++it)
+		for (auto it = m_components.begin(); it != m_components.end(); ++it)
 		{
 			if ((*it) == nullptr || (*it)->GetGameObject() == nullptr)
 			{
@@ -90,13 +89,13 @@ namespace fl
 		}
 
 		component->SetGameObject(this);
-		m_components->push_back(component);
+		m_components.push_back(component);
 		return component;
 	}
 
 	Component *GameObject::RemoveComponent(Component *component)
 	{
-		for (auto it = m_components->begin(); it != m_components->end(); ++it)
+		for (auto it = m_components.begin(); it != m_components.end(); ++it)
 		{
 			if (*it == component)
 			{
@@ -106,7 +105,7 @@ namespace fl
 				}
 
 				delete component;
-				m_components->erase(it);
+				m_components.erase(it);
 				return *it;
 			}
 		}

--- a/Sources/Objects/GameObject.hpp
+++ b/Sources/Objects/GameObject.hpp
@@ -9,12 +9,13 @@
 
 namespace fl
 {
-	class FL_EXPORT GameObject
+	class FL_EXPORT GameObject :
+		public std::enable_shared_from_this<GameObject>
 	{
 	private:
 		std::string m_name;
 		Transform *m_transform;
-		std::vector<Component *> m_components;
+		std::vector<std::shared_ptr<Component>> m_components;
 		ISpatialStructure *m_structure;
 		GameObject* m_parent;
 		bool m_removed;
@@ -27,14 +28,14 @@ namespace fl
 
 		virtual void Update();
 
-		std::vector<Component *> GetComponents() const { return m_components; }
+		std::vector<std::shared_ptr<Component>> GetComponents() const { return m_components; }
 
 		template<typename T>
-		T *GetComponent()
+		std::shared_ptr<T> GetComponent()
 		{
 			for (auto c : m_components)
 			{
-				T *casted = dynamic_cast<T *>(c);
+				auto casted = std::dynamic_pointer_cast<T>(c);
 
 				if (casted != nullptr)
 				{
@@ -45,29 +46,29 @@ namespace fl
 			return nullptr;
 		}
 
-		Component *AddComponent(Component *component);
+		std::shared_ptr<Component> AddComponent(std::shared_ptr<Component> component);
 
 		template<typename T, typename... Args>
-		T *AddComponent(Args &&... args)
+		std::shared_ptr<T> AddComponent(Args &&... args)
 		{
-			T *created = new T(std::forward<Args>(args)...);
+			auto created = std::make_shared<T>(std::forward<Args>(args)...);
 			AddComponent(created);
 			return created;
 		}
 
-		Component *RemoveComponent(Component *component);
+		std::shared_ptr<Component> RemoveComponent(std::shared_ptr<Component> component);
 
 		template<typename T>
-		T *RemoveComponent()
+		std::shared_ptr<T> RemoveComponent()
 		{
-			for (auto c : m_components)
+			for (auto component : m_components)
 			{
-				T *casted = dynamic_cast<T *>(c);
+				auto casted = std::dynamic_pointer_cast<T>(component);
 
 				if (casted != nullptr)
 				{
-					RemoveComponent(c);
-					return c;
+					RemoveComponent(component);
+					return component;
 				}
 			}
 

--- a/Sources/Objects/GameObject.hpp
+++ b/Sources/Objects/GameObject.hpp
@@ -13,7 +13,7 @@ namespace fl
 	private:
 		std::string m_name;
 		Transform *m_transform;
-		std::vector<Component *> *m_components;
+		std::vector<Component *> m_components;
 		ISpatialStructure *m_structure;
 		GameObject *m_parent;
 		bool m_removed;
@@ -26,12 +26,12 @@ namespace fl
 
 		virtual void Update();
 
-		std::vector<Component *> *GetComponents() const { return m_components; }
+		std::vector<Component *> GetComponents() const { return m_components; }
 
 		template<typename T>
 		T *GetComponent()
 		{
-			for (auto c : *m_components)
+			for (auto c : m_components)
 			{
 				T *casted = dynamic_cast<T *>(c);
 
@@ -59,7 +59,7 @@ namespace fl
 		template<typename T>
 		T *RemoveComponent()
 		{
-			for (auto c : *m_components)
+			for (auto c : m_components)
 			{
 				T *casted = dynamic_cast<T *>(c);
 

--- a/Sources/Objects/GameObject.hpp
+++ b/Sources/Objects/GameObject.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <memory>
 #include "Engine/Exports.hpp"
 #include "Scenes/ISpatialStructure.hpp"
 #include "Maths/Transform.hpp"
@@ -15,10 +16,10 @@ namespace fl
 		Transform *m_transform;
 		std::vector<Component *> m_components;
 		ISpatialStructure *m_structure;
-		GameObject *m_parent;
+		GameObject* m_parent;
 		bool m_removed;
 	public:
-		GameObject(const Transform &transform, ISpatialStructure *structure = nullptr, const std::string &name = "Unnamed");
+		GameObject(const Transform &transform, ISpatialStructure *structure = nullptr);
 
 		GameObject(const std::string &prefabName, const Transform &transform, ISpatialStructure *structure = nullptr);
 

--- a/Sources/Objects/Prefabs/PrefabObject.cpp
+++ b/Sources/Objects/Prefabs/PrefabObject.cpp
@@ -8,33 +8,32 @@ namespace fl
 	PrefabObject::PrefabObject(const std::string &filename) :
 		IResource(),
 		m_filename(filename),
-		m_fileJson(new FileJson(filename))
+		m_fileJson(FileJson(filename))
 	{
 		if (!FileSystem::FileExists(filename))
 		{
 			FileSystem::CreateFile(filename);
 		}
 
-		m_fileJson->Load();
+		m_fileJson.Load();
 	}
 
 	PrefabObject::~PrefabObject()
 	{
-		delete m_fileJson;
 	}
 
-	void PrefabObject::Write(GameObject *gameObject)
+	void PrefabObject::Write(const GameObject &gameObject)
 	{
-		m_fileJson->Clear();
+		m_fileJson.Clear();
 
-		for (auto component : *gameObject->GetComponents())
+		for (auto component : gameObject.GetComponents())
 		{
-			component->Write(m_fileJson->GetParent()->GetChild(component->GetName(), true));
+			component->Write(m_fileJson.GetParent()->GetChild(component->GetName(), true));
 		}
 	}
 
 	void PrefabObject::Save()
 	{
-		m_fileJson->Save();
+		m_fileJson.Save();
 	}
 }

--- a/Sources/Objects/Prefabs/PrefabObject.hpp
+++ b/Sources/Objects/Prefabs/PrefabObject.hpp
@@ -21,17 +21,17 @@ namespace fl
 		std::string m_filename;
 		FileJson *m_fileJson;
 	public:
-		static PrefabObject *Resource(const std::string &filename)
+		static std::shared_ptr<PrefabObject> Resource(const std::string &filename)
 		{
-			IResource *resource = Resources::Get()->Get(filename);
+			auto resource = Resources::Get()->Get(filename);
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<PrefabObject *>(resource);
+				return std::dynamic_pointer_cast<PrefabObject>(resource);
 			}
 
-			PrefabObject *result = new PrefabObject(filename);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<PrefabObject>(filename);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 

--- a/Sources/Objects/Prefabs/PrefabObject.hpp
+++ b/Sources/Objects/Prefabs/PrefabObject.hpp
@@ -19,7 +19,7 @@ namespace fl
 	{
 	private:
 		std::string m_filename;
-		FileJson *m_fileJson;
+		FileJson m_fileJson;
 	public:
 		static std::shared_ptr<PrefabObject> Resource(const std::string &filename)
 		{
@@ -43,12 +43,12 @@ namespace fl
 
 		~PrefabObject();
 
-		void Write(GameObject *gameObject);
+		void Write(const GameObject &gameObject);
 
 		void Save();
 
 		std::string GetFilename() override { return m_filename; }
 
-		LoadedValue *GetParent() const { return m_fileJson->GetParent(); }
+		LoadedValue *GetParent() const { return m_fileJson.GetParent(); }
 	};
 }

--- a/Sources/Particles/Particle.cpp
+++ b/Sources/Particles/Particle.cpp
@@ -53,20 +53,20 @@ namespace fl
 			return;
 		}
 
-		Vector3 cameraToParticle = *Scenes::Get()->GetCamera()->GetPosition() - *m_position;
+		Vector3 cameraToParticle = Scenes::Get()->GetCamera()->GetPosition() - *m_position;
 		m_distanceToCamera = cameraToParticle.LengthSquared();
 
-		const float lifeFactor = m_elapsedTime / m_lifeLength;
+		float lifeFactor = m_elapsedTime / m_lifeLength;
 
 		if (m_particleType->GetTexture() == nullptr)
 		{
 			return;
 		}
 
-		const int stageCount = static_cast<int>(pow(m_particleType->GetTexture()->GetNumberOfRows(), 2));
-		const float atlasProgression = lifeFactor * stageCount;
-		const int index1 = static_cast<int>(std::floor(atlasProgression));
-		const int index2 = index1 < stageCount - 1 ? index1 + 1 : index1;
+		int stageCount = static_cast<int>(pow(m_particleType->GetTexture()->GetNumberOfRows(), 2));
+		float atlasProgression = lifeFactor * stageCount;
+		int index1 = static_cast<int>(std::floor(atlasProgression));
+		int index2 = index1 < stageCount - 1 ? index1 + 1 : index1;
 
 		m_textureBlendFactor = std::fmod(atlasProgression, 1.0f);
 		UpdateTextureOffset(m_textureOffset1, index1);

--- a/Sources/Particles/Particle.cpp
+++ b/Sources/Particles/Particle.cpp
@@ -7,11 +7,11 @@ namespace fl
 {
 	Particle::Particle(ParticleType *particleType, const Vector3 &position, const Vector3 &velocity, const float &lifeLength, const float &rotation, const float &scale, const float &gravityEffect) :
 		m_particleType(particleType),
-		m_position(new Vector3(position)),
-		m_velocity(new Vector3(velocity)),
-		m_change(new Vector3()),
-		m_textureOffset1(new Vector2()),
-		m_textureOffset2(new Vector2()),
+		m_position(Vector3(position)),
+		m_velocity(Vector3(velocity)),
+		m_change(Vector3()),
+		m_textureOffset1(Vector2()),
+		m_textureOffset2(Vector2()),
 		m_lifeLength(lifeLength),
 		m_rotation(rotation),
 		m_scale(scale),
@@ -25,22 +25,15 @@ namespace fl
 
 	Particle::~Particle()
 	{
-		delete m_position;
-
-		delete m_velocity;
-		delete m_change;
-
-		delete m_textureOffset1;
-		delete m_textureOffset2;
 	}
 
 	void Particle::Update()
 	{
-		m_velocity->m_y += -10.0f * m_gravityEffect * Engine::Get()->GetDelta();
-		*m_change = *m_velocity;
-		*m_change *= Engine::Get()->GetDelta();
+		m_velocity.m_y += -10.0f * m_gravityEffect * Engine::Get()->GetDelta();
+		m_change = m_velocity;
+		m_change *= Engine::Get()->GetDelta();
 
-		*m_position += *m_change;
+		m_position += m_change;
 		m_elapsedTime += Engine::Get()->GetDelta();
 
 		if (m_elapsedTime > m_lifeLength)
@@ -53,7 +46,7 @@ namespace fl
 			return;
 		}
 
-		Vector3 cameraToParticle = Scenes::Get()->GetCamera()->GetPosition() - *m_position;
+		Vector3 cameraToParticle = Scenes::Get()->GetCamera()->GetPosition() - m_position;
 		m_distanceToCamera = cameraToParticle.LengthSquared();
 
 		float lifeFactor = m_elapsedTime / m_lifeLength;
@@ -69,8 +62,8 @@ namespace fl
 		int index2 = index1 < stageCount - 1 ? index1 + 1 : index1;
 
 		m_textureBlendFactor = std::fmod(atlasProgression, 1.0f);
-		UpdateTextureOffset(m_textureOffset1, index1);
-		UpdateTextureOffset(m_textureOffset2, index2);
+		m_textureOffset1 = CalculateTextureOffset(index1);
+		m_textureOffset2 = CalculateTextureOffset(index2);
 	}
 
 	bool Particle::operator<(const Particle &other) const
@@ -78,12 +71,13 @@ namespace fl
 		return m_distanceToCamera > other.m_distanceToCamera;
 	}
 
-	Vector2 *Particle::UpdateTextureOffset(Vector2 *offset, const int &index) const
+	Vector2 Particle::CalculateTextureOffset(const int &index) const
 	{
-		const int column = index % m_particleType->GetTexture()->GetNumberOfRows();
-		const int row = index / m_particleType->GetTexture()->GetNumberOfRows();
-		offset->m_x = static_cast<float>(column) / m_particleType->GetTexture()->GetNumberOfRows();
-		offset->m_y = static_cast<float>(row) / m_particleType->GetTexture()->GetNumberOfRows();
-		return offset;
+		int column = index % m_particleType->GetTexture()->GetNumberOfRows();
+		int row = index / m_particleType->GetTexture()->GetNumberOfRows();
+		Vector2 result = Vector2();
+		result.m_x = static_cast<float>(column) / m_particleType->GetTexture()->GetNumberOfRows();
+		result.m_y = static_cast<float>(row) / m_particleType->GetTexture()->GetNumberOfRows();
+		return result;
 	}
 }

--- a/Sources/Particles/Particle.cpp
+++ b/Sources/Particles/Particle.cpp
@@ -5,7 +5,7 @@
 
 namespace fl
 {
-	Particle::Particle(ParticleType *particleType, const Vector3 &position, const Vector3 &velocity, const float &lifeLength, const float &rotation, const float &scale, const float &gravityEffect) :
+	Particle::Particle(std::shared_ptr<ParticleType> particleType, const Vector3 &position, const Vector3 &velocity, const float &lifeLength, const float &rotation, const float &scale, const float &gravityEffect) :
 		m_particleType(particleType),
 		m_position(Vector3(position)),
 		m_velocity(Vector3(velocity)),

--- a/Sources/Particles/Particle.hpp
+++ b/Sources/Particles/Particle.hpp
@@ -12,7 +12,7 @@ namespace fl
 	class FL_EXPORT Particle
 	{
 	private:
-		ParticleType *m_particleType;
+		std::shared_ptr<ParticleType> m_particleType;
 
 		Vector3 m_position;
 
@@ -42,7 +42,7 @@ namespace fl
 		/// <param name="rotation"> The particles rotation. </param>
 		/// <param name="scale"> The particles scale. </param>
 		/// <param name="gravityEffect"> The particles gravity effect. </param>
-		Particle(ParticleType *particleType, const Vector3 &position, const Vector3 &velocity, const float &lifeLength, const float &rotation, const float &scale, const float &gravityEffect);
+		Particle(std::shared_ptr<ParticleType> particleType, const Vector3 &position, const Vector3 &velocity, const float &lifeLength, const float &rotation, const float &scale, const float &gravityEffect);
 
 		/// <summary>
 		/// Deconstructor for the particle.
@@ -56,7 +56,7 @@ namespace fl
 
 		bool IsAlive() const { return m_transparency < 1.0f; }
 
-		ParticleType *GetParticleType() const { return m_particleType; }
+		std::shared_ptr<ParticleType> GetParticleType() const { return m_particleType; }
 
 		Vector3 GetPosition() const { return m_position; }
 

--- a/Sources/Particles/Particle.hpp
+++ b/Sources/Particles/Particle.hpp
@@ -14,13 +14,13 @@ namespace fl
 	private:
 		ParticleType *m_particleType;
 
-		Vector3 *m_position;
+		Vector3 m_position;
 
-		Vector3 *m_velocity;
-		Vector3 *m_change;
+		Vector3 m_velocity;
+		Vector3 m_change;
 
-		Vector2 *m_textureOffset1;
-		Vector2 *m_textureOffset2;
+		Vector2 m_textureOffset1;
+		Vector2 m_textureOffset2;
 
 		float m_lifeLength;
 		float m_rotation;
@@ -58,15 +58,15 @@ namespace fl
 
 		ParticleType *GetParticleType() const { return m_particleType; }
 
-		Vector3 *GetPosition() const { return m_position; }
+		Vector3 GetPosition() const { return m_position; }
 
-		Vector3 *GetVelocity() const { return m_velocity; }
+		Vector3 GetVelocity() const { return m_velocity; }
 
-		Vector3 *GetChange() const { return m_change; }
+		Vector3 GetChange() const { return m_change; }
 
-		Vector2 *GetTextureOffset1() const { return m_textureOffset1; }
+		Vector2 GetTextureOffset1() const { return m_textureOffset1; }
 
-		Vector2 *GetTextureOffset2() const { return m_textureOffset2; }
+		Vector2 GetTextureOffset2() const { return m_textureOffset2; }
 
 		float GetLifeLength() const { return m_lifeLength; }
 
@@ -87,6 +87,6 @@ namespace fl
 		bool operator<(const Particle &other) const;
 
 	private:
-		Vector2 *UpdateTextureOffset(Vector2 *offset, const int &index) const;
+		Vector2 CalculateTextureOffset(const int &index) const;
 	};
 }

--- a/Sources/Particles/ParticleSystem.cpp
+++ b/Sources/Particles/ParticleSystem.cpp
@@ -86,8 +86,8 @@ namespace fl
 
 		Vector3 velocity = Vector3();
 		float delta = Engine::Get()->GetDelta();
-		velocity = *GetGameObject()->GetTransform()->GetPosition() - *m_lastPosition;
-		*m_lastPosition = *GetGameObject()->GetTransform()->GetPosition();
+		velocity = GetGameObject()->GetTransform()->GetPosition() - *m_lastPosition;
+		*m_lastPosition = GetGameObject()->GetTransform()->GetPosition();
 		velocity /= delta;
 
 		if (m_direction != nullptr)
@@ -106,7 +106,7 @@ namespace fl
 		float scale = GenerateValue(emitType->GetScale(), emitType->GetScale() * Maths::RandomInRange(1.0f - m_scaleError, 1.0f + m_scaleError));
 		float lifeLength = GenerateValue(emitType->GetLifeLength(), emitType->GetLifeLength() * Maths::RandomInRange(1.0f - m_lifeError, 1.0f + m_lifeError));
 		Vector3 spawnPos = Vector3();
-		spawnPos = *GetGameObject()->GetTransform()->GetPosition() + *m_systemOffset;
+		spawnPos = GetGameObject()->GetTransform()->GetPosition() + *m_systemOffset;
 		spawnPos = spawnPos + *m_spawn->GetBaseSpawnPosition();
 		return new Particle(emitType, spawnPos, velocity, lifeLength, GenerateRotation(), scale, m_gravityEffect);
 	}

--- a/Sources/Particles/ParticleSystem.cpp
+++ b/Sources/Particles/ParticleSystem.cpp
@@ -126,7 +126,7 @@ namespace fl
 
 	void ParticleSystem::AddParticleType(std::shared_ptr<ParticleType> type)
 	{
-		m_types.push_back(type);
+		m_types.emplace_back(type);
 	}
 
 	void ParticleSystem::RemoveParticleType(std::shared_ptr<ParticleType> type)

--- a/Sources/Particles/ParticleSystem.cpp
+++ b/Sources/Particles/ParticleSystem.cpp
@@ -107,7 +107,7 @@ namespace fl
 		float lifeLength = GenerateValue(emitType->GetLifeLength(), emitType->GetLifeLength() * Maths::RandomInRange(1.0f - m_lifeError, 1.0f + m_lifeError));
 		Vector3 spawnPos = Vector3();
 		spawnPos = GetGameObject()->GetTransform()->GetPosition() + *m_systemOffset;
-		spawnPos = spawnPos + *m_spawn->GetBaseSpawnPosition();
+		spawnPos = spawnPos + m_spawn->GetBaseSpawnPosition();
 		return new Particle(emitType, spawnPos, velocity, lifeLength, GenerateRotation(), scale, m_gravityEffect);
 	}
 

--- a/Sources/Particles/ParticleSystem.hpp
+++ b/Sources/Particles/ParticleSystem.hpp
@@ -17,7 +17,7 @@ namespace fl
 		public Component
 	{
 	private:
-		std::vector<ParticleType *> *m_types;
+		std::vector<std::shared_ptr<ParticleType>> m_types;
 		ISpawnParticle *m_spawn;
 
 		float m_pps;
@@ -25,10 +25,10 @@ namespace fl
 		float m_gravityEffect;
 		bool m_randomRotation;
 
-		Vector3 *m_lastPosition;
+		Vector3 m_lastPosition;
 
-		Vector3 *m_systemOffset;
-		Vector3 *m_direction;
+		Vector3 m_systemOffset;
+		Vector3 m_direction;
 		float m_directionDeviation;
 		float m_speedError;
 		float m_lifeError;
@@ -46,7 +46,7 @@ namespace fl
 		/// <param name="averageSpeed"> Particle average speed. </param>
 		/// <param name="gravityEffect"> How much gravity will effect the particles. </param>
 		/// <param name="systemOffset"> The offset from the parents centre. </param>
-		ParticleSystem(std::vector<ParticleType *> *types = new std::vector<ParticleType *>(), ISpawnParticle *spawn = nullptr, const float &pps = 5.0f, const float &averageSpeed = 0.2f, const float &gravityEffect = 1.0f, const Vector3 &systemOffset = Vector3::ZERO);
+		ParticleSystem(const std::vector<std::shared_ptr<ParticleType>> &types = std::vector<std::shared_ptr<ParticleType>>(), ISpawnParticle *spawn = nullptr, const float &pps = 5.0f, const float &averageSpeed = 0.2f, const float &gravityEffect = 1.0f, const Vector3 &systemOffset = Vector3::ZERO);
 
 		/// <summary>
 		/// Deconstructor for the particle system.
@@ -71,9 +71,9 @@ namespace fl
 	public:
 		std::string GetName() const override { return "ParticleSystem"; };
 
-		void AddParticleType(ParticleType *type) const;
+		void AddParticleType(std::shared_ptr<ParticleType> type);
 
-		void RemoveParticleType(ParticleType *type) const;
+		void RemoveParticleType(std::shared_ptr<ParticleType> type);
 
 		ISpawnParticle *GetSpawn() const { return m_spawn; }
 
@@ -95,11 +95,11 @@ namespace fl
 
 		void SetRandomRotation(const bool &randomRotation) { m_randomRotation = randomRotation; }
 
-		Vector3 *GetOffsetCentre() const { return m_systemOffset; }
+		Vector3 GetOffsetCentre() const { return m_systemOffset; }
 
-		void SetOffsetCentre(const Vector3 &systemOffsetCentre) { *m_systemOffset = systemOffsetCentre; }
+		void SetOffsetCentre(const Vector3 &systemOffsetCentre) { m_systemOffset = systemOffsetCentre; }
 
-		Vector3 *GetDirection() const { return m_direction; }
+		Vector3 GetDirection() const { return m_direction; }
 
 		void SetDirection(const Vector3 &direction, const float &deviation);
 

--- a/Sources/Particles/ParticleType.cpp
+++ b/Sources/Particles/ParticleType.cpp
@@ -2,7 +2,7 @@
 
 namespace fl
 {
-	ParticleType::ParticleType(const std::string &name, Texture *texture, const float &lifeLength, const float &scale) :
+	ParticleType::ParticleType(const std::string &name, std::shared_ptr<Texture> texture, const float &lifeLength, const float &scale) :
 		m_name(name),
 		m_texture(texture),
 		m_lifeLength(lifeLength),

--- a/Sources/Particles/ParticleType.hpp
+++ b/Sources/Particles/ParticleType.hpp
@@ -16,6 +16,8 @@ namespace fl
 		float m_lifeLength;
 		float m_scale;
 	public:
+		// TODO: Switch to using a resource function `std::shared_ptr<ParticleType>`.
+
 		/// <summary>
 		/// Creates a new particle type.
 		/// </summary>

--- a/Sources/Particles/ParticleType.hpp
+++ b/Sources/Particles/ParticleType.hpp
@@ -12,7 +12,7 @@ namespace fl
 	{
 	private:
 		std::string m_name;
-		Texture *m_texture;
+		std::shared_ptr<Texture> m_texture;
 		float m_lifeLength;
 		float m_scale;
 	public:
@@ -23,7 +23,7 @@ namespace fl
 		/// <param name="texture"> The particles texture. </param>
 		/// <param name="lifeLength"> The averaged life length for the particle. </param>
 		/// <param name="scale"> The averaged scale for the particle. </param>
-		ParticleType(const std::string &name, Texture *texture, const float &lifeLength, const float &scale);
+		ParticleType(const std::string &name, std::shared_ptr<Texture> texture, const float &lifeLength, const float &scale);
 
 		/// <summary>
 		/// Deconstructor for the particle type.
@@ -34,9 +34,9 @@ namespace fl
 
 		void SetName(const std::string &name) { m_name = name; }
 
-		Texture *GetTexture() const { return m_texture; }
+		std::shared_ptr<Texture> GetTexture() const { return m_texture; }
 
-		void SetTexture(Texture *texture) { m_texture = texture; }
+		void SetTexture(std::shared_ptr<Texture> texture) { m_texture = texture; }
 
 		float GetLifeLength() const { return m_lifeLength; }
 

--- a/Sources/Particles/Particles.cpp
+++ b/Sources/Particles/Particles.cpp
@@ -8,13 +8,12 @@ namespace fl
 
 	Particles::Particles() :
 		IModule(),
-		m_particles(new std::map<ParticleType *, std::vector<Particle *> *>())
+		m_particles(std::map<ParticleType *, std::vector<Particle *>>())
 	{
 	}
 
 	Particles::~Particles()
 	{
-		delete m_particles;
 	}
 
 	void Particles::Update()
@@ -24,17 +23,16 @@ namespace fl
 			return;
 		}
 
-		// Update and kill particles.
-		for (auto it = m_particles->begin(); it != m_particles->end(); ++it)
+		for (auto it = m_particles.begin(); it != m_particles.end(); ++it)
 		{
-			for (auto it1 = (*it).second->begin(); it1 != (*it).second->end(); ++it1)
+			for (auto it1 = (*it).second.begin(); it1 != (*it).second.end(); ++it1)
 			{
 				(*it1)->Update();
 
 				if (!(*it1)->IsAlive())
 				{
 					delete *it1;
-					(*it).second->erase(it1);
+					(*it).second.erase(it1);
 				}
 			}
 		}
@@ -47,22 +45,19 @@ namespace fl
 			return;
 		}
 
-		auto list = m_particles->find(created->GetParticleType());
+		auto list = m_particles.find(created->GetParticleType());
 
-		if (list == m_particles->end())
+		if (list == m_particles.end())
 		{
-			m_particles->insert(std::make_pair(created->GetParticleType(), new std::vector<Particle *>()));
-			list = m_particles->find(created->GetParticleType());
+			m_particles.insert(std::make_pair(created->GetParticleType(), std::vector<Particle *>()));
+			list = m_particles.find(created->GetParticleType());
 		}
 
-		if ((*list).second != nullptr)
-		{
-			(*list).second->push_back(created);
-		}
+		(*list).second.push_back(created);
 	}
 
 	void Particles::Clear()
 	{
-		m_particles->clear();
+		m_particles.clear();
 	}
 }

--- a/Sources/Particles/Particles.cpp
+++ b/Sources/Particles/Particles.cpp
@@ -8,7 +8,7 @@ namespace fl
 
 	Particles::Particles() :
 		IModule(),
-		m_particles(std::map<ParticleType *, std::vector<Particle *>>())
+		m_particles(std::map<std::shared_ptr<ParticleType>, std::vector<Particle *>>())
 	{
 	}
 

--- a/Sources/Particles/Particles.cpp
+++ b/Sources/Particles/Particles.cpp
@@ -49,11 +49,11 @@ namespace fl
 
 		if (list == m_particles.end())
 		{
-			m_particles.insert(std::make_pair(created->GetParticleType(), std::vector<Particle *>()));
+			m_particles.emplace(created->GetParticleType(), std::vector<Particle *>());
 			list = m_particles.find(created->GetParticleType());
 		}
 
-		(*list).second.push_back(created);
+		(*list).second.emplace_back(created);
 	}
 
 	void Particles::Clear()

--- a/Sources/Particles/Particles.hpp
+++ b/Sources/Particles/Particles.hpp
@@ -16,7 +16,7 @@ namespace fl
 	private:
 		static const float MAX_ELAPSED_TIME;
 
-		std::map<ParticleType *, std::vector<Particle *> *> *m_particles;
+		std::map<ParticleType *, std::vector<Particle *>> m_particles;
 	public:
 		/// <summary>
 		/// Gets this engine instance.
@@ -50,6 +50,6 @@ namespace fl
 		/// Gets a list of all particles.
 		/// </summary>
 		/// <returns> All particles. </returns>
-		std::map<ParticleType *, std::vector<Particle *> *> *GetParticles() const { return m_particles; }
+		std::map<ParticleType *, std::vector<Particle *>> GetParticles() const { return m_particles; }
 	};
 }

--- a/Sources/Particles/Particles.hpp
+++ b/Sources/Particles/Particles.hpp
@@ -16,7 +16,7 @@ namespace fl
 	private:
 		static const float MAX_ELAPSED_TIME;
 
-		std::map<ParticleType *, std::vector<Particle *>> m_particles;
+		std::map<std::shared_ptr<ParticleType>, std::vector<Particle *>> m_particles;
 	public:
 		/// <summary>
 		/// Gets this engine instance.
@@ -50,6 +50,6 @@ namespace fl
 		/// Gets a list of all particles.
 		/// </summary>
 		/// <returns> All particles. </returns>
-		std::map<ParticleType *, std::vector<Particle *>> GetParticles() const { return m_particles; }
+		std::map<std::shared_ptr<ParticleType>, std::vector<Particle *>> GetParticles() const { return m_particles; }
 	};
 }

--- a/Sources/Particles/RendererParticles.cpp
+++ b/Sources/Particles/RendererParticles.cpp
@@ -51,7 +51,7 @@ namespace fl
 
 	Matrix4 RendererParticles::ModelMatrix(Particle *particle, const Matrix4 &viewMatrix)
 	{
-		Matrix4 modelMatrix = modelMatrix.Translate(*particle->GetPosition());
+		Matrix4 modelMatrix = modelMatrix.Translate(particle->GetPosition());
 		modelMatrix.m_00 = viewMatrix.m_00;
 		modelMatrix.m_01 = viewMatrix.m_10;
 		modelMatrix.m_02 = viewMatrix.m_20;

--- a/Sources/Particles/RendererParticles.cpp
+++ b/Sources/Particles/RendererParticles.cpp
@@ -6,16 +6,14 @@ namespace fl
 {
 	RendererParticles::RendererParticles(const GraphicsStage &graphicsStage) :
 		IRenderer(),
-		m_uniformScene(new UniformHandler()),
-		m_pipeline(new Pipeline(graphicsStage, PipelineCreate({"Resources/Shaders/Particles/Particle.vert", "Resources/Shaders/Particles/Particle.frag"},
+		m_uniformScene(UniformHandler()),
+		m_pipeline(Pipeline(graphicsStage, PipelineCreate({"Resources/Shaders/Particles/Particle.vert", "Resources/Shaders/Particles/Particle.frag"},
 			VertexModel::GetVertexInput(), PIPELINE_MODE_MRT, PIPELINE_POLYGON_MODE_FILL, PIPELINE_CULL_MODE_BACK), {}))
 	{
 	}
 
 	RendererParticles::~RendererParticles()
 	{
-		delete m_uniformScene;
-		delete m_pipeline;
 	}
 
 	void RendererParticles::Render(const CommandBuffer &commandBuffer, const Vector4 &clipPlane, const ICamera &camera)

--- a/Sources/Particles/RendererParticles.cpp
+++ b/Sources/Particles/RendererParticles.cpp
@@ -18,8 +18,8 @@ namespace fl
 
 	void RendererParticles::Render(const CommandBuffer &commandBuffer, const Vector4 &clipPlane, const ICamera &camera)
 	{
-		/*const auto logicalDevice = Display::Get()->GetLogicalDevice();
-		const auto descriptorSet = m_pipeline->GetDescriptorSet();
+		/*auto logicalDevice = Display::Get()->GetLogicalDevice();
+		auto descriptorSet = m_pipeline->GetDescriptorSet();
 
 		UbosParticles::UboScene uboScene = {};
 		uboScene.projection = camera.GetProjectionMatrix();
@@ -42,7 +42,7 @@ namespace fl
 				object.textureOffsets.m_w = particle->GetTextureOffset2()->m_y;
 				object.blendFactor = particle->GetTextureBlendFactor();
 				object.transparency = particle->GetTransparency();
-				objects.push_back(object);
+				objects.emplace_back(object);
 			}
 		}*/
 	}

--- a/Sources/Particles/RendererParticles.cpp
+++ b/Sources/Particles/RendererParticles.cpp
@@ -24,8 +24,8 @@ namespace fl
 		const auto descriptorSet = m_pipeline->GetDescriptorSet();
 
 		UbosParticles::UboScene uboScene = {};
-		uboScene.projection = *camera.GetProjectionMatrix();
-		uboScene.view = *camera.GetViewMatrix();
+		uboScene.projection = camera.GetProjectionMatrix();
+		uboScene.view = camera.GetViewMatrix();
 		m_uniformScene->Update(&uboScene);
 
 		m_pipeline->BindPipeline(commandBuffer);*/
@@ -37,7 +37,7 @@ namespace fl
 			for (auto particle : *(*iter).second)
 			{
 				UbosParticles::UboObject object = {};
-				object.transform = ModelMatrix(particle, *camera.GetViewMatrix());
+				object.transform = ModelMatrix(particle, camera.GetViewMatrix());
 				object.textureOffsets.m_x = particle->GetTextureOffset1()->m_x;
 				object.textureOffsets.m_y = particle->GetTextureOffset1()->m_y;
 				object.textureOffsets.m_z = particle->GetTextureOffset2()->m_x;

--- a/Sources/Particles/RendererParticles.hpp
+++ b/Sources/Particles/RendererParticles.hpp
@@ -13,8 +13,8 @@ namespace fl
 		public IRenderer
 	{
 	private:
-		UniformHandler *m_uniformScene;
-		Pipeline *m_pipeline;
+		UniformHandler m_uniformScene;
+		Pipeline m_pipeline;
 	public:
 		RendererParticles(const GraphicsStage &graphicsStage);
 

--- a/Sources/Particles/Spawns/ISpawnParticle.hpp
+++ b/Sources/Particles/Spawns/ISpawnParticle.hpp
@@ -28,6 +28,6 @@ namespace fl
 		/// Gets the base spawn position.
 		/// </summary>
 		/// <returns> The base spawn position. </returns>
-		virtual Vector3 *GetBaseSpawnPosition() = 0;
+		virtual Vector3 GetBaseSpawnPosition() = 0;
 	};
 }

--- a/Sources/Particles/Spawns/SpawnCircle.cpp
+++ b/Sources/Particles/Spawns/SpawnCircle.cpp
@@ -5,21 +5,18 @@ namespace fl
 	SpawnCircle::SpawnCircle(const float &radius, const Vector3 &heading) :
 		ISpawnParticle(),
 		m_radius(radius),
-		m_heading(new Vector3(heading)),
-		m_spawnPosition(new Vector3())
+		m_heading(heading.Normalize()),
+		m_spawnPosition(Vector3())
 	{
-		m_heading->Normalize();
 	}
 
 	SpawnCircle::~SpawnCircle()
 	{
-		delete m_heading;
-		delete m_spawnPosition;
 	}
 
-	Vector3 *SpawnCircle::GetBaseSpawnPosition()
+	Vector3 SpawnCircle::GetBaseSpawnPosition()
 	{
-		*m_spawnPosition = Vector3::RandomPointOnCircle(*m_heading, m_radius);
+		m_spawnPosition = Vector3::RandomPointOnCircle(m_heading, m_radius);
 		return m_spawnPosition;
 	}
 }

--- a/Sources/Particles/Spawns/SpawnCircle.hpp
+++ b/Sources/Particles/Spawns/SpawnCircle.hpp
@@ -9,21 +9,21 @@ namespace fl
 	{
 	private:
 		float m_radius;
-		Vector3 *m_heading;
-		Vector3 *m_spawnPosition;
+		Vector3 m_heading;
+		Vector3 m_spawnPosition;
 	public:
 		SpawnCircle(const float &radius, const Vector3 &heading);
 
 		~SpawnCircle();
 
-		Vector3 *GetBaseSpawnPosition() override;
+		Vector3 GetBaseSpawnPosition() override;
 
 		float GetRadius() const { return m_radius; }
 
 		void SetRadius(const float &radius) { m_radius = radius; }
 
-		Vector3 *GetHeading() const { return m_heading; }
+		Vector3 GetHeading() const { return m_heading; }
 
-		void SetHeading(const Vector3 &heading) { *m_heading = heading; }
+		void SetHeading(const Vector3 &heading) { m_heading = heading; }
 	};
 }

--- a/Sources/Particles/Spawns/SpawnLine.cpp
+++ b/Sources/Particles/Spawns/SpawnLine.cpp
@@ -7,23 +7,20 @@ namespace fl
 	SpawnLine::SpawnLine(const float &length, const Vector3 &axis) :
 		ISpawnParticle(),
 		m_length(length),
-		m_axis(new Vector3(axis)),
-		m_spawnPosition(new Vector3())
+		m_axis(Vector3(axis.Normalize())),
+		m_spawnPosition(Vector3())
 	{
-		m_axis->Normalize();
 	}
 
 	SpawnLine::~SpawnLine()
 	{
-		delete m_axis;
-		delete m_spawnPosition;
 	}
 
-	Vector3 *SpawnLine::GetBaseSpawnPosition()
+	Vector3 SpawnLine::GetBaseSpawnPosition()
 	{
-		*m_spawnPosition = *m_axis;
-		*m_spawnPosition *= m_length;
-		*m_spawnPosition *= Maths::RandomInRange(-0.5f, 0.5f);
+		m_spawnPosition = m_axis;
+		m_spawnPosition *= m_length;
+		m_spawnPosition *= Maths::RandomInRange(-0.5f, 0.5f);
 		return m_spawnPosition;
 	}
 }

--- a/Sources/Particles/Spawns/SpawnLine.hpp
+++ b/Sources/Particles/Spawns/SpawnLine.hpp
@@ -9,25 +9,21 @@ namespace fl
 	{
 	private:
 		float m_length;
-		Vector3 *m_axis;
-		Vector3 *m_spawnPosition;
+		Vector3 m_axis;
+		Vector3 m_spawnPosition;
 	public:
 		SpawnLine(const float &length, const Vector3 &axis);
 
 		~SpawnLine();
 
-		Vector3 *GetBaseSpawnPosition() override;
+		Vector3 GetBaseSpawnPosition() override;
 
 		float GetLength() const { return m_length; }
 
 		void SetLength(const float &length) { m_length = length; }
 
-		Vector3 *GetAxis() const { return m_axis; }
+		Vector3 GetAxis() const { return m_axis; }
 
-		void SetAxis(const Vector3 &axis) { *m_axis = axis; }
-
-		Vector3 *GetSpawnPosition() const { return m_spawnPosition; }
-
-		void SetSpawnPosition(const Vector3 &spawnPosition) { *m_spawnPosition = spawnPosition; }
+		void SetAxis(const Vector3 &axis) { m_axis = axis; }
 	};
 }

--- a/Sources/Particles/Spawns/SpawnPoint.cpp
+++ b/Sources/Particles/Spawns/SpawnPoint.cpp
@@ -4,16 +4,15 @@ namespace fl
 {
 	SpawnPoint::SpawnPoint() :
 		ISpawnParticle(),
-		m_point(new Vector3())
+		m_point(Vector3())
 	{
 	}
 
 	SpawnPoint::~SpawnPoint()
 	{
-		delete m_point;
 	}
 
-	Vector3 *SpawnPoint::GetBaseSpawnPosition()
+	Vector3 SpawnPoint::GetBaseSpawnPosition()
 	{
 		return m_point;
 	}

--- a/Sources/Particles/Spawns/SpawnPoint.hpp
+++ b/Sources/Particles/Spawns/SpawnPoint.hpp
@@ -8,16 +8,16 @@ namespace fl
 		public ISpawnParticle
 	{
 	private:
-		Vector3 *m_point;
+		Vector3 m_point;
 	public:
 		SpawnPoint();
 
 		~SpawnPoint();
 
-		Vector3 *GetBaseSpawnPosition() override;
+		Vector3 GetBaseSpawnPosition() override;
 
-		Vector3 *getPoint() const { return m_point; }
+		Vector3 GetPoint() const { return m_point; }
 
-		void setPoint(const Vector3 &point) { *m_point = point; }
+		void SetPoint(const Vector3 &point) { m_point = point; }
 	};
 }

--- a/Sources/Particles/Spawns/SpawnSphere.cpp
+++ b/Sources/Particles/Spawns/SpawnSphere.cpp
@@ -8,34 +8,33 @@ namespace fl
 	SpawnSphere::SpawnSphere(const float &radius, const Vector3 &heading) :
 		ISpawnParticle(),
 		m_radius(radius),
-		m_spawnPosition(new Vector3())
+		m_spawnPosition(Vector3())
 	{
 	}
 
 	SpawnSphere::~SpawnSphere()
 	{
-		delete m_spawnPosition;
 	}
 
-	Vector3 *SpawnSphere::GetBaseSpawnPosition()
+	Vector3 SpawnSphere::GetBaseSpawnPosition()
 	{
-		*m_spawnPosition = Vector3::RandomUnitVector();
+		m_spawnPosition = Vector3::RandomUnitVector();
 
-		m_spawnPosition->Scale(m_radius);
+		m_spawnPosition *= m_radius;
 		float a = Maths::RandomInRange(0.0f, 1.0f);
 		float b = Maths::RandomInRange(0.0f, 1.0f);
 
 		if (a > b)
 		{
-			const float temp = a;
+			float temp = a;
 			a = b;
 			b = temp;
 		}
 
-		const float randX = b * std::cos(2.0f * PI * (a / b));
-		const float randY = b * std::sin(2.0f * PI * (a / b));
-		const float distance = Vector2(randX, randY).Length();
-		*m_spawnPosition *= distance;
+		float randX = b * std::cos(2.0f * PI * (a / b));
+		float randY = b * std::sin(2.0f * PI * (a / b));
+		float distance = Vector2(randX, randY).Length();
+		m_spawnPosition *= distance;
 		return m_spawnPosition;
 	}
 }

--- a/Sources/Particles/Spawns/SpawnSphere.hpp
+++ b/Sources/Particles/Spawns/SpawnSphere.hpp
@@ -9,13 +9,13 @@ namespace fl
 	{
 	private:
 		float m_radius;
-		Vector3 *m_spawnPosition;
+		Vector3 m_spawnPosition;
 	public:
 		SpawnSphere(const float &radius, const Vector3 &heading);
 
 		~SpawnSphere();
 
-		Vector3 *GetBaseSpawnPosition() override;
+		Vector3 GetBaseSpawnPosition() override;
 
 		float GetRadius() const { return m_radius; }
 

--- a/Sources/Physics/ColliderAabb.cpp
+++ b/Sources/Physics/ColliderAabb.cpp
@@ -175,38 +175,38 @@ namespace fl
 		*source->m_maxExtents = *m_maxExtents;
 
 		// Scales the dimensions for the aabb.
-		if (*transform.GetScaling() != 1.0f)
+		if (transform.GetScaling() != 1.0f)
 		{
-			*source->m_minExtents = Vector3(source->m_minExtents->m_x * transform.GetScaling()->m_x, source->m_minExtents->m_y * transform.GetScaling()->m_y, source->m_minExtents->m_z * transform.GetScaling()->m_z);
-			*source->m_maxExtents = Vector3(source->m_maxExtents->m_x * transform.GetScaling()->m_x, source->m_maxExtents->m_y * transform.GetScaling()->m_y, source->m_maxExtents->m_z * transform.GetScaling()->m_z);
+			*source->m_minExtents = Vector3(source->m_minExtents->m_x * transform.GetScaling().m_x, source->m_minExtents->m_y * transform.GetScaling().m_y, source->m_minExtents->m_z * transform.GetScaling().m_z);
+			*source->m_maxExtents = Vector3(source->m_maxExtents->m_x * transform.GetScaling().m_x, source->m_maxExtents->m_y * transform.GetScaling().m_y, source->m_maxExtents->m_z * transform.GetScaling().m_z);
 		}
 
 		// Creates the 8 aabb corners and rotates them.
-		if (*transform.GetRotation() != 0.0f)
+		if (transform.GetRotation() != 0.0f)
 		{
 			Vector3 fll = Vector3(source->m_minExtents->m_x, source->m_minExtents->m_y, source->m_minExtents->m_z);
-			fll = fll.Rotate(*transform.GetRotation());
+			fll = fll.Rotate(transform.GetRotation());
 
 			Vector3 flr = Vector3(source->m_maxExtents->m_x, source->m_minExtents->m_y, source->m_minExtents->m_z);
-			flr = flr.Rotate(*transform.GetRotation());
+			flr = flr.Rotate(transform.GetRotation());
 
 			Vector3 ful = Vector3(source->m_minExtents->m_x, source->m_maxExtents->m_y, source->m_minExtents->m_z);
-			ful = ful.Rotate(*transform.GetRotation());
+			ful = ful.Rotate(transform.GetRotation());
 
 			Vector3 fur = Vector3(source->m_maxExtents->m_x, source->m_maxExtents->m_y, source->m_minExtents->m_z);
-			fur = fur.Rotate(*transform.GetRotation());
+			fur = fur.Rotate(transform.GetRotation());
 
 			Vector3 bur = Vector3(source->m_maxExtents->m_x, source->m_maxExtents->m_y, source->m_maxExtents->m_z);
-			bur = bur.Rotate(*transform.GetRotation());
+			bur = bur.Rotate(transform.GetRotation());
 
 			Vector3 bul = Vector3(source->m_minExtents->m_x, source->m_maxExtents->m_y, source->m_maxExtents->m_z);
-			bul = bul.Rotate(*transform.GetRotation());
+			bul = bul.Rotate(transform.GetRotation());
 
 			Vector3 blr = Vector3(source->m_maxExtents->m_x, source->m_minExtents->m_y, source->m_maxExtents->m_z);
-			blr = blr.Rotate(*transform.GetRotation());
+			blr = blr.Rotate(transform.GetRotation());
 
 			Vector3 bll = Vector3(source->m_minExtents->m_x, source->m_minExtents->m_y, source->m_maxExtents->m_z);
-			bll = bll.Rotate(*transform.GetRotation());
+			bll = bll.Rotate(transform.GetRotation());
 
 			//source->m_minExtents = min(fll, min(flr, min(ful, min(fur, min(bur, min(bul, min(blr, bll)))))));
 			*source->m_minExtents = Vector3::MinVector(fll, flr);
@@ -228,10 +228,10 @@ namespace fl
 		}
 
 		// Transforms the aabb.
-		if (*transform.GetPosition() != 0.0f)
+		if (transform.GetPosition() != 0.0f)
 		{
-			*source->m_minExtents = *source->m_minExtents + *transform.GetPosition();
-			*source->m_maxExtents = *source->m_maxExtents + *transform.GetPosition();
+			*source->m_minExtents = *source->m_minExtents + transform.GetPosition();
+			*source->m_maxExtents = *source->m_maxExtents + transform.GetPosition();
 		}
 
 		// Returns the final aabb.

--- a/Sources/Physics/ColliderAabb.cpp
+++ b/Sources/Physics/ColliderAabb.cpp
@@ -4,38 +4,22 @@
 
 namespace fl
 {
-	ColliderAabb::ColliderAabb() :
-		ICollider(),
-		m_minExtents(new Vector3()),
-		m_maxExtents(new Vector3())
-	{
-	}
-
 	ColliderAabb::ColliderAabb(const Vector3 &minExtents, const Vector3 &maxExtents) :
 		ICollider(),
-		m_minExtents(new Vector3(minExtents)),
-		m_maxExtents(new Vector3(maxExtents))
+		m_minExtents(Vector3(minExtents)),
+		m_maxExtents(Vector3(maxExtents))
 	{
 	}
 
 	ColliderAabb::ColliderAabb(const ColliderAabb &source) :
 		ICollider(),
-		m_minExtents(new Vector3(*source.m_minExtents)),
-		m_maxExtents(new Vector3(*source.m_maxExtents))
+		m_minExtents(Vector3(source.m_minExtents)),
+		m_maxExtents(Vector3(source.m_maxExtents))
 	{
 	}
 
 	ColliderAabb::~ColliderAabb()
 	{
-		delete m_minExtents;
-		delete m_maxExtents;
-	}
-
-	ColliderAabb *ColliderAabb::Set(const ColliderAabb &source)
-	{
-		*m_minExtents = *source.m_minExtents;
-		*m_maxExtents = *source.m_maxExtents;
-		return this;
 	}
 
 	ColliderAabb *ColliderAabb::Scale(const ColliderAabb &source, const Vector3 &scale, ColliderAabb *destination)
@@ -45,10 +29,10 @@ namespace fl
 			destination = new ColliderAabb();
 		}
 
-		*destination->m_minExtents = Vector3(source.m_minExtents->m_x * scale.m_x,
-			source.m_minExtents->m_y * scale.m_y, source.m_minExtents->m_z * scale.m_z);
-		*destination->m_maxExtents = Vector3(source.m_maxExtents->m_x * scale.m_x,
-			source.m_maxExtents->m_y * scale.m_y, source.m_maxExtents->m_z * scale.m_z);
+		destination->m_minExtents = Vector3(source.m_minExtents.m_x * scale.m_x,
+			source.m_minExtents.m_y * scale.m_y, source.m_minExtents.m_z * scale.m_z);
+		destination->m_maxExtents = Vector3(source.m_maxExtents.m_x * scale.m_x,
+			source.m_maxExtents.m_y * scale.m_y, source.m_maxExtents.m_z * scale.m_z);
 
 		return destination;
 	}
@@ -65,10 +49,10 @@ namespace fl
 			destination = new ColliderAabb();
 		}
 
-		*destination->m_minExtents = Vector3(source.m_minExtents->m_x - expand.m_x,
-			source.m_minExtents->m_y - expand.m_y, source.m_minExtents->m_z - expand.m_z);
-		*destination->m_maxExtents = Vector3(source.m_maxExtents->m_x + expand.m_x,
-			source.m_maxExtents->m_y + expand.m_y, source.m_maxExtents->m_z + expand.m_z);
+		destination->m_minExtents = Vector3(source.m_minExtents.m_x - expand.m_x,
+			source.m_minExtents.m_y - expand.m_y, source.m_minExtents.m_z - expand.m_z);
+		destination->m_maxExtents = Vector3(source.m_maxExtents.m_x + expand.m_x,
+			source.m_maxExtents.m_y + expand.m_y, source.m_maxExtents.m_z + expand.m_z);
 
 		return destination;
 	}
@@ -85,15 +69,15 @@ namespace fl
 			destination = new ColliderAabb();
 		}
 
-		float newMinX = std::min(left.m_minExtents->m_x, right.m_minExtents->m_x);
-		float newMinY = std::min(left.m_minExtents->m_y, right.m_minExtents->m_y);
-		float newMinZ = std::min(left.m_minExtents->m_z, right.m_minExtents->m_z);
-		float newMaxX = std::max(left.m_maxExtents->m_x, right.m_maxExtents->m_x);
-		float newMaxY = std::max(left.m_maxExtents->m_y, right.m_maxExtents->m_y);
-		float newMaxZ = std::max(left.m_maxExtents->m_z, right.m_maxExtents->m_z);
+		float newMinX = std::min(left.m_minExtents.m_x, right.m_minExtents.m_x);
+		float newMinY = std::min(left.m_minExtents.m_y, right.m_minExtents.m_y);
+		float newMinZ = std::min(left.m_minExtents.m_z, right.m_minExtents.m_z);
+		float newMaxX = std::max(left.m_maxExtents.m_x, right.m_maxExtents.m_x);
+		float newMaxY = std::max(left.m_maxExtents.m_y, right.m_maxExtents.m_y);
+		float newMaxZ = std::max(left.m_maxExtents.m_z, right.m_maxExtents.m_z);
 
-		*destination->m_minExtents = Vector3(newMinX, newMinY, newMinZ);
-		*destination->m_maxExtents = Vector3(newMaxX, newMaxY, newMaxZ);
+		destination->m_minExtents = Vector3(newMinX, newMinY, newMinZ);
+		destination->m_maxExtents = Vector3(newMaxX, newMaxY, newMaxZ);
 
 		return destination;
 	}
@@ -109,39 +93,39 @@ namespace fl
 
 		if (stretch.m_x < 0.0f)
 		{
-			newMinX = source.m_minExtents->m_x + stretch.m_x;
-			newMaxX = source.m_maxExtents->m_x;
+			newMinX = source.m_minExtents.m_x + stretch.m_x;
+			newMaxX = source.m_maxExtents.m_x;
 		}
 		else
 		{
-			newMinX = source.m_minExtents->m_x;
-			newMaxX = source.m_maxExtents->m_x + stretch.m_x;
+			newMinX = source.m_minExtents.m_x;
+			newMaxX = source.m_maxExtents.m_x + stretch.m_x;
 		}
 
 		if (stretch.m_y < 0.0f)
 		{
-			newMinY = source.m_minExtents->m_y + stretch.m_y;
-			newMaxY = source.m_maxExtents->m_y;
+			newMinY = source.m_minExtents.m_y + stretch.m_y;
+			newMaxY = source.m_maxExtents.m_y;
 		}
 		else
 		{
-			newMinY = source.m_minExtents->m_y;
-			newMaxY = source.m_maxExtents->m_y + stretch.m_y;
+			newMinY = source.m_minExtents.m_y;
+			newMaxY = source.m_maxExtents.m_y + stretch.m_y;
 		}
 
 		if (stretch.m_z < 0.0f)
 		{
-			newMinZ = source.m_minExtents->m_z + stretch.m_z;
-			newMaxZ = source.m_maxExtents->m_z;
+			newMinZ = source.m_minExtents.m_z + stretch.m_z;
+			newMaxZ = source.m_maxExtents.m_z;
 		}
 		else
 		{
-			newMinZ = source.m_minExtents->m_z;
-			newMaxZ = source.m_maxExtents->m_z + stretch.m_z;
+			newMinZ = source.m_minExtents.m_z;
+			newMaxZ = source.m_maxExtents.m_z + stretch.m_z;
 		}
 
-		*destination->m_minExtents = Vector3(newMinX, newMinY, newMinZ);
-		*destination->m_maxExtents = Vector3(newMaxX, newMaxY, newMaxZ);
+		destination->m_minExtents = Vector3(newMinX, newMinY, newMinZ);
+		destination->m_maxExtents = Vector3(newMaxX, newMaxY, newMaxZ);
 
 		return destination;
 	}
@@ -171,67 +155,67 @@ namespace fl
 		}
 
 		// Sets the destinations values to the sources.
-		*source->m_minExtents = *m_minExtents;
-		*source->m_maxExtents = *m_maxExtents;
+		source->m_minExtents = m_minExtents;
+		source->m_maxExtents = m_maxExtents;
 
 		// Scales the dimensions for the aabb.
 		if (transform.GetScaling() != 1.0f)
 		{
-			*source->m_minExtents = Vector3(source->m_minExtents->m_x * transform.GetScaling().m_x, source->m_minExtents->m_y * transform.GetScaling().m_y, source->m_minExtents->m_z * transform.GetScaling().m_z);
-			*source->m_maxExtents = Vector3(source->m_maxExtents->m_x * transform.GetScaling().m_x, source->m_maxExtents->m_y * transform.GetScaling().m_y, source->m_maxExtents->m_z * transform.GetScaling().m_z);
+			source->m_minExtents = Vector3(source->m_minExtents.m_x * transform.GetScaling().m_x, source->m_minExtents.m_y * transform.GetScaling().m_y, source->m_minExtents.m_z * transform.GetScaling().m_z);
+			source->m_maxExtents = Vector3(source->m_maxExtents.m_x * transform.GetScaling().m_x, source->m_maxExtents.m_y * transform.GetScaling().m_y, source->m_maxExtents.m_z * transform.GetScaling().m_z);
 		}
 
 		// Creates the 8 aabb corners and rotates them.
 		if (transform.GetRotation() != 0.0f)
 		{
-			Vector3 fll = Vector3(source->m_minExtents->m_x, source->m_minExtents->m_y, source->m_minExtents->m_z);
+			Vector3 fll = Vector3(source->m_minExtents.m_x, source->m_minExtents.m_y, source->m_minExtents.m_z);
 			fll = fll.Rotate(transform.GetRotation());
 
-			Vector3 flr = Vector3(source->m_maxExtents->m_x, source->m_minExtents->m_y, source->m_minExtents->m_z);
+			Vector3 flr = Vector3(source->m_maxExtents.m_x, source->m_minExtents.m_y, source->m_minExtents.m_z);
 			flr = flr.Rotate(transform.GetRotation());
 
-			Vector3 ful = Vector3(source->m_minExtents->m_x, source->m_maxExtents->m_y, source->m_minExtents->m_z);
+			Vector3 ful = Vector3(source->m_minExtents.m_x, source->m_maxExtents.m_y, source->m_minExtents.m_z);
 			ful = ful.Rotate(transform.GetRotation());
 
-			Vector3 fur = Vector3(source->m_maxExtents->m_x, source->m_maxExtents->m_y, source->m_minExtents->m_z);
+			Vector3 fur = Vector3(source->m_maxExtents.m_x, source->m_maxExtents.m_y, source->m_minExtents.m_z);
 			fur = fur.Rotate(transform.GetRotation());
 
-			Vector3 bur = Vector3(source->m_maxExtents->m_x, source->m_maxExtents->m_y, source->m_maxExtents->m_z);
+			Vector3 bur = Vector3(source->m_maxExtents.m_x, source->m_maxExtents.m_y, source->m_maxExtents.m_z);
 			bur = bur.Rotate(transform.GetRotation());
 
-			Vector3 bul = Vector3(source->m_minExtents->m_x, source->m_maxExtents->m_y, source->m_maxExtents->m_z);
+			Vector3 bul = Vector3(source->m_minExtents.m_x, source->m_maxExtents.m_y, source->m_maxExtents.m_z);
 			bul = bul.Rotate(transform.GetRotation());
 
-			Vector3 blr = Vector3(source->m_maxExtents->m_x, source->m_minExtents->m_y, source->m_maxExtents->m_z);
+			Vector3 blr = Vector3(source->m_maxExtents.m_x, source->m_minExtents.m_y, source->m_maxExtents.m_z);
 			blr = blr.Rotate(transform.GetRotation());
 
-			Vector3 bll = Vector3(source->m_minExtents->m_x, source->m_minExtents->m_y, source->m_maxExtents->m_z);
+			Vector3 bll = Vector3(source->m_minExtents.m_x, source->m_minExtents.m_y, source->m_maxExtents.m_z);
 			bll = bll.Rotate(transform.GetRotation());
 
 			//source->m_minExtents = min(fll, min(flr, min(ful, min(fur, min(bur, min(bul, min(blr, bll)))))));
-			*source->m_minExtents = Vector3::MinVector(fll, flr);
-			*source->m_minExtents = Vector3::MinVector(*source->m_minExtents, ful);
-			*source->m_minExtents = Vector3::MinVector(*source->m_minExtents, fur);
-			*source->m_minExtents = Vector3::MinVector(*source->m_minExtents, bur);
-			*source->m_minExtents = Vector3::MinVector(*source->m_minExtents, bul);
-			*source->m_minExtents = Vector3::MinVector(*source->m_minExtents, blr);
-			*source->m_minExtents = Vector3::MinVector(*source->m_minExtents, bll);
+			source->m_minExtents = Vector3::MinVector(fll, flr);
+			source->m_minExtents = Vector3::MinVector(source->m_minExtents, ful);
+			source->m_minExtents = Vector3::MinVector(source->m_minExtents, fur);
+			source->m_minExtents = Vector3::MinVector(source->m_minExtents, bur);
+			source->m_minExtents = Vector3::MinVector(source->m_minExtents, bul);
+			source->m_minExtents = Vector3::MinVector(source->m_minExtents, blr);
+			source->m_minExtents = Vector3::MinVector(source->m_minExtents, bll);
 
 			//source->m_maxExtents = max(fll, max(flr, max(ful, max(fur, max(bur, max(bul, max(blr, bll)))))));
-			*source->m_maxExtents = Vector3::MaxVector(fll, flr);
-			*source->m_maxExtents = Vector3::MaxVector(*source->m_maxExtents, ful);
-			*source->m_maxExtents = Vector3::MaxVector(*source->m_maxExtents, fur);
-			*source->m_maxExtents = Vector3::MaxVector(*source->m_maxExtents, bur);
-			*source->m_maxExtents = Vector3::MaxVector(*source->m_maxExtents, bul);
-			*source->m_maxExtents = Vector3::MaxVector(*source->m_maxExtents, blr);
-			*source->m_maxExtents = Vector3::MaxVector(*source->m_maxExtents, bll);
+			source->m_maxExtents = Vector3::MaxVector(fll, flr);
+			source->m_maxExtents = Vector3::MaxVector(source->m_maxExtents, ful);
+			source->m_maxExtents = Vector3::MaxVector(source->m_maxExtents, fur);
+			source->m_maxExtents = Vector3::MaxVector(source->m_maxExtents, bur);
+			source->m_maxExtents = Vector3::MaxVector(source->m_maxExtents, bul);
+			source->m_maxExtents = Vector3::MaxVector(source->m_maxExtents, blr);
+			source->m_maxExtents = Vector3::MaxVector(source->m_maxExtents, bll);
 		}
 
 		// Transforms the aabb.
 		if (transform.GetPosition() != 0.0f)
 		{
-			*source->m_minExtents = *source->m_minExtents + transform.GetPosition();
-			*source->m_maxExtents = *source->m_maxExtents + transform.GetPosition();
+			source->m_minExtents = source->m_minExtents + transform.GetPosition();
+			source->m_maxExtents = source->m_maxExtents + transform.GetPosition();
 		}
 
 		// Returns the final aabb.
@@ -245,7 +229,7 @@ namespace fl
 			destination = new Vector3();
 		}
 
-		const ColliderAabb &aabb2 = dynamic_cast<const ColliderAabb &>(other);
+		auto aabb2 = dynamic_cast<const ColliderAabb &>(other);
 
 		if (positionDelta.m_x != 0.0f)
 		{
@@ -254,12 +238,12 @@ namespace fl
 			if (positionDelta.m_x >= 0.0f)
 			{
 				// Our max == their min
-				newAmountX = aabb2.m_minExtents->m_x - m_maxExtents->m_x;
+				newAmountX = aabb2.m_minExtents.m_x - m_maxExtents.m_x;
 			}
 			else
 			{
 				// Our min == their max
-				newAmountX = aabb2.m_maxExtents->m_x - m_minExtents->m_x;
+				newAmountX = aabb2.m_maxExtents.m_x - m_minExtents.m_x;
 			}
 
 			if (std::fabs(newAmountX) < std::fabs(positionDelta.m_x))
@@ -275,12 +259,12 @@ namespace fl
 			if (positionDelta.m_y >= 0.0f)
 			{
 				// Our max == their min
-				newAmountY = aabb2.m_minExtents->m_y - m_maxExtents->m_y;
+				newAmountY = aabb2.m_minExtents.m_y - m_maxExtents.m_y;
 			}
 			else
 			{
 				// Our min == their max
-				newAmountY = aabb2.m_maxExtents->m_y - m_minExtents->m_y;
+				newAmountY = aabb2.m_maxExtents.m_y - m_minExtents.m_y;
 			}
 
 			if (std::fabs(newAmountY) < std::fabs(positionDelta.m_y))
@@ -296,12 +280,12 @@ namespace fl
 			if (positionDelta.m_z >= 0.0f)
 			{
 				// Our max == their min
-				newAmountZ = aabb2.m_minExtents->m_z - m_maxExtents->m_z;
+				newAmountZ = aabb2.m_minExtents.m_z - m_maxExtents.m_z;
 			}
 			else
 			{
 				// Our min == their max
-				newAmountZ = aabb2.m_maxExtents->m_z - m_minExtents->m_z;
+				newAmountZ = aabb2.m_maxExtents.m_z - m_minExtents.m_z;
 			}
 
 			if (std::fabs(newAmountZ) < std::fabs(positionDelta.m_z))
@@ -315,10 +299,10 @@ namespace fl
 
 	Intersect ColliderAabb::Intersects(const ICollider &other)
 	{
-		const ColliderAabb &aabb2 = dynamic_cast<const ColliderAabb &>(other);
+		auto aabb2 = dynamic_cast<const ColliderAabb &>(other);
 
-		Vector3 distance1 = *m_minExtents - *aabb2.m_maxExtents;
-		Vector3 distance2 = *aabb2.m_minExtents - *m_maxExtents;
+		Vector3 distance1 = m_minExtents - aabb2.m_maxExtents;
+		Vector3 distance2 = aabb2.m_minExtents - m_maxExtents;
 		Vector3 maxDistance = Vector3::MaxVector(distance1, distance2);
 		float maxDist = maxDistance.MaxComponent();
 
@@ -330,31 +314,31 @@ namespace fl
 
 			float distanceSquared = sphere->getRadius() * sphere->getRadius();
 
-			if (sphere->getPosition()->m_x < m_minExtents->m_x)
+			if (sphere->getPosition()->m_x < m_minExtents.m_x)
 			{
-				distanceSquared -= pow(sphere->getPosition()->m_x - m_minExtents->m_x, 2);
+				distanceSquared -= pow(sphere->getPosition()->m_x - m_minExtents.m_x, 2);
 			}
-			else if (sphere->getPosition()->m_x > m_maxExtents->m_x)
+			else if (sphere->getPosition()->m_x > m_maxExtents.m_x)
 			{
-				distanceSquared -= pow(sphere->getPosition()->m_x - m_maxExtents->m_x, 2);
-			}
-
-			if (sphere->getPosition()->m_y < m_minExtents->m_x)
-			{
-				distanceSquared -= pow(sphere->getPosition()->m_y - m_minExtents->m_y, 2);
-			}
-			else if (sphere->getPosition()->m_x > m_maxExtents->m_x)
-			{
-				distanceSquared -= pow(sphere->getPosition()->m_y - m_maxExtents->m_y, 2);
+				distanceSquared -= pow(sphere->getPosition()->m_x - m_maxExtents.m_x, 2);
 			}
 
-			if (sphere->getPosition()->m_z < m_minExtents->m_x)
+			if (sphere->getPosition()->m_y < m_minExtents.m_x)
 			{
-				distanceSquared -= pow(sphere->getPosition()->m_z - m_minExtents->m_z, 2);
+				distanceSquared -= pow(sphere->getPosition()->m_y - m_minExtents.m_y, 2);
 			}
-			else if (sphere->getPosition()->m_z > m_maxExtents->m_x)
+			else if (sphere->getPosition()->m_x > m_maxExtents.m_x)
 			{
-				distanceSquared -= pow(sphere->getPosition()->m_z - m_maxExtents->m_z, 2);
+				distanceSquared -= pow(sphere->getPosition()->m_y - m_maxExtents.m_y, 2);
+			}
+
+			if (sphere->getPosition()->m_z < m_minExtents.m_x)
+			{
+				distanceSquared -= pow(sphere->getPosition()->m_z - m_minExtents.m_z, 2);
+			}
+			else if (sphere->getPosition()->m_z > m_maxExtents.m_x)
+			{
+				distanceSquared -= pow(sphere->getPosition()->m_z - m_maxExtents.m_z, 2);
 			}
 
 			return new intersect(distanceSquared > 0.0f, sqrt(distanceSquared));
@@ -363,22 +347,22 @@ namespace fl
 
 	Intersect ColliderAabb::Intersects(const Ray &ray)
 	{
-		double tmin = (m_minExtents->m_x - ray.GetOrigin().m_x) / ray.GetCurrentRay().m_x;
-		double tmax = (m_maxExtents->m_x - ray.GetOrigin().m_x) / ray.GetCurrentRay().m_x;
+		float tmin = (m_minExtents.m_x - ray.GetOrigin().m_x) / ray.GetCurrentRay().m_x;
+		float tmax = (m_maxExtents.m_x - ray.GetOrigin().m_x) / ray.GetCurrentRay().m_x;
 
 		if (tmin > tmax)
 		{
-			const double temp = tmax;
+			float temp = tmax;
 			tmax = tmin;
 			tmin = temp;
 		}
 
-		float tymin = (m_minExtents->m_y - ray.GetOrigin().m_y) / ray.GetCurrentRay().m_y;
-		float tymax = (m_maxExtents->m_y - ray.GetOrigin().m_y) / ray.GetCurrentRay().m_y;
+		float tymin = (m_minExtents.m_y - ray.GetOrigin().m_y) / ray.GetCurrentRay().m_y;
+		float tymax = (m_maxExtents.m_y - ray.GetOrigin().m_y) / ray.GetCurrentRay().m_y;
 
 		if (tymin > tymax)
 		{
-			const float temp = tymax;
+			float temp = tymax;
 			tymax = tymin;
 			tymin = temp;
 		}
@@ -398,12 +382,12 @@ namespace fl
 			tmax = tymax;
 		}
 
-		float tzmin = (m_minExtents->m_z - ray.GetOrigin().m_z) / ray.GetCurrentRay().m_z;
-		float tzmax = (m_maxExtents->m_z - ray.GetOrigin().m_z) / ray.GetCurrentRay().m_z;
+		float tzmin = (m_minExtents.m_z - ray.GetOrigin().m_z) / ray.GetCurrentRay().m_z;
+		float tzmax = (m_maxExtents.m_z - ray.GetOrigin().m_z) / ray.GetCurrentRay().m_z;
 
 		if (tzmin > tzmax)
 		{
-			const float temp = tzmax;
+			float temp = tzmax;
 			tzmax = tzmin;
 			tzmin = temp;
 		}
@@ -413,49 +397,49 @@ namespace fl
 
 	bool ColliderAabb::InFrustum(const Frustum &frustum)
 	{
-		return frustum.CubeInFrustum(*m_minExtents, *m_maxExtents);
+		return frustum.CubeInFrustum(m_minExtents, m_maxExtents);
 	}
 
 	bool ColliderAabb::Contains(const ICollider &other)
 	{
-		const ColliderAabb &aabb2 = dynamic_cast<const ColliderAabb &>(other);
+		auto aabb2 = dynamic_cast<const ColliderAabb &>(other);
 
-		return m_minExtents->m_x <= aabb2.m_minExtents->m_x &&
-			aabb2.m_maxExtents->m_x <= m_maxExtents->m_x &&
-			m_minExtents->m_y <= aabb2.m_minExtents->m_y &&
-			aabb2.m_maxExtents->m_y <= m_maxExtents->m_y &&
-			m_minExtents->m_z <= aabb2.m_minExtents->m_z &&
-			aabb2.m_maxExtents->m_z <= m_maxExtents->m_z;
+		return m_minExtents.m_x <= aabb2.m_minExtents.m_x &&
+			aabb2.m_maxExtents.m_x <= m_maxExtents.m_x &&
+			m_minExtents.m_y <= aabb2.m_minExtents.m_y &&
+			aabb2.m_maxExtents.m_y <= m_maxExtents.m_y &&
+			m_minExtents.m_z <= aabb2.m_minExtents.m_z &&
+			aabb2.m_maxExtents.m_z <= m_maxExtents.m_z;
 	}
 
 	bool ColliderAabb::Contains(const Vector3 &point)
 	{
-		if (point.m_x > m_maxExtents->m_x)
+		if (point.m_x > m_maxExtents.m_x)
 		{
 			return false;
 		}
 
-		if (point.m_x < m_minExtents->m_x)
+		if (point.m_x < m_minExtents.m_x)
 		{
 			return false;
 		}
 
-		if (point.m_y > m_maxExtents->m_y)
+		if (point.m_y > m_maxExtents.m_y)
 		{
 			return false;
 		}
 
-		if (point.m_y < m_minExtents->m_y)
+		if (point.m_y < m_minExtents.m_y)
 		{
 			return false;
 		}
 
-		if (point.m_z > m_maxExtents->m_z)
+		if (point.m_z > m_maxExtents.m_z)
 		{
 			return false;
 		}
 
-		if (point.m_z < m_minExtents->m_z)
+		if (point.m_z < m_minExtents.m_z)
 		{
 			return false;
 		}
@@ -465,31 +449,48 @@ namespace fl
 
 	float ColliderAabb::GetCentreX() const
 	{
-		return (m_minExtents->m_x + m_maxExtents->m_x) / 2.0f;
+		return (m_minExtents.m_x + m_maxExtents.m_x) / 2.0f;
 	}
 
 	float ColliderAabb::GetCentreY() const
 	{
-		return (m_minExtents->m_y + m_maxExtents->m_y) / 2.0f;
+		return (m_minExtents.m_y + m_maxExtents.m_y) / 2.0f;
 	}
 
 	float ColliderAabb::GetCentreZ() const
 	{
-		return (m_minExtents->m_z + m_maxExtents->m_z) / 2.0f;
+		return (m_minExtents.m_z + m_maxExtents.m_z) / 2.0f;
 	}
 
 	float ColliderAabb::GetWidth() const
 	{
-		return m_maxExtents->m_x - m_minExtents->m_x;
+		return m_maxExtents.m_x - m_minExtents.m_x;
 	}
 
 	float ColliderAabb::GetHeight() const
 	{
-		return m_maxExtents->m_y - m_minExtents->m_y;
+		return m_maxExtents.m_y - m_minExtents.m_y;
 	}
 
 	float ColliderAabb::GetDepth() const
 	{
-		return m_maxExtents->m_z - m_minExtents->m_z;
+		return m_maxExtents.m_z - m_minExtents.m_z;
+	}
+
+	ColliderAabb &ColliderAabb::operator=(const ColliderAabb &other)
+	{
+		m_minExtents = other.m_minExtents;
+		m_maxExtents = other.m_maxExtents;
+		return *this;
+	}
+
+	bool ColliderAabb::operator==(const ColliderAabb &other) const
+	{
+		return m_minExtents == other.m_minExtents && m_maxExtents == other.m_maxExtents;
+	}
+
+	bool ColliderAabb::operator!=(const ColliderAabb &other) const
+	{
+		return !(*this == other);
 	}
 }

--- a/Sources/Physics/ColliderAabb.cpp
+++ b/Sources/Physics/ColliderAabb.cpp
@@ -22,117 +22,82 @@ namespace fl
 	{
 	}
 
-	ColliderAabb *ColliderAabb::Scale(const ColliderAabb &source, const Vector3 &scale, ColliderAabb *destination)
+	ColliderAabb ColliderAabb::Scale(const Vector3 &scale)
 	{
-		if (destination == nullptr)
-		{
-			destination = new ColliderAabb();
-		}
+		Vector3 minExtents = Vector3(m_minExtents.m_x * scale.m_x,
+			m_minExtents.m_y * scale.m_y, m_minExtents.m_z * scale.m_z);
+		Vector3 maxExtents = Vector3(m_maxExtents.m_x * scale.m_x,
+			m_maxExtents.m_y * scale.m_y, m_maxExtents.m_z * scale.m_z);
 
-		destination->m_minExtents = Vector3(source.m_minExtents.m_x * scale.m_x,
-			source.m_minExtents.m_y * scale.m_y, source.m_minExtents.m_z * scale.m_z);
-		destination->m_maxExtents = Vector3(source.m_maxExtents.m_x * scale.m_x,
-			source.m_maxExtents.m_y * scale.m_y, source.m_maxExtents.m_z * scale.m_z);
-
-		return destination;
+		return ColliderAabb(minExtents, maxExtents);
 	}
 
-	ColliderAabb *ColliderAabb::Scale(const ColliderAabb &source, const float &scaleX, const float &scaleY, const float &scaleZ, ColliderAabb *destination)
+	ColliderAabb ColliderAabb::Expand(const Vector3 &expand)
 	{
-		return Scale(source, Vector3(scaleX, scaleY, scaleZ), destination);
+		Vector3 minExtents = Vector3(m_minExtents.m_x - expand.m_x,
+			m_minExtents.m_y - expand.m_y, m_minExtents.m_z - expand.m_z);
+		Vector3 maxExtents = Vector3(m_maxExtents.m_x + expand.m_x,
+			m_maxExtents.m_y + expand.m_y, m_maxExtents.m_z + expand.m_z);
+
+		return ColliderAabb(minExtents, maxExtents);
 	}
 
-	ColliderAabb *ColliderAabb::Expand(const ColliderAabb &source, const Vector3 &expand, ColliderAabb *destination)
+	ColliderAabb ColliderAabb::Combine(const ColliderAabb &other)
 	{
-		if (destination == nullptr)
-		{
-			destination = new ColliderAabb();
-		}
+		float newMinX = std::min(m_minExtents.m_x, other.m_minExtents.m_x);
+		float newMinY = std::min(m_minExtents.m_y, other.m_minExtents.m_y);
+		float newMinZ = std::min(m_minExtents.m_z, other.m_minExtents.m_z);
+		float newMaxX = std::max(m_maxExtents.m_x, other.m_maxExtents.m_x);
+		float newMaxY = std::max(m_maxExtents.m_y, other.m_maxExtents.m_y);
+		float newMaxZ = std::max(m_maxExtents.m_z, other.m_maxExtents.m_z);
 
-		destination->m_minExtents = Vector3(source.m_minExtents.m_x - expand.m_x,
-			source.m_minExtents.m_y - expand.m_y, source.m_minExtents.m_z - expand.m_z);
-		destination->m_maxExtents = Vector3(source.m_maxExtents.m_x + expand.m_x,
-			source.m_maxExtents.m_y + expand.m_y, source.m_maxExtents.m_z + expand.m_z);
+		Vector3 minExtents = Vector3(newMinX, newMinY, newMinZ);
+		Vector3 maxExtents = Vector3(newMaxX, newMaxY, newMaxZ);
 
-		return destination;
+		return ColliderAabb(minExtents, maxExtents);
 	}
 
-	ColliderAabb *ColliderAabb::Expand(const ColliderAabb &source, const float &expandX, const float &expandY, const float &expandZ, ColliderAabb *destination)
+	ColliderAabb ColliderAabb::Stretch(const Vector3 &stretch)
 	{
-		return Expand(source, Vector3(expandX, expandY, expandZ), destination);
-	}
-
-	ColliderAabb *ColliderAabb::Combine(const ColliderAabb &left, const ColliderAabb &right, ColliderAabb *destination)
-	{
-		if (destination == nullptr)
-		{
-			destination = new ColliderAabb();
-		}
-
-		float newMinX = std::min(left.m_minExtents.m_x, right.m_minExtents.m_x);
-		float newMinY = std::min(left.m_minExtents.m_y, right.m_minExtents.m_y);
-		float newMinZ = std::min(left.m_minExtents.m_z, right.m_minExtents.m_z);
-		float newMaxX = std::max(left.m_maxExtents.m_x, right.m_maxExtents.m_x);
-		float newMaxY = std::max(left.m_maxExtents.m_y, right.m_maxExtents.m_y);
-		float newMaxZ = std::max(left.m_maxExtents.m_z, right.m_maxExtents.m_z);
-
-		destination->m_minExtents = Vector3(newMinX, newMinY, newMinZ);
-		destination->m_maxExtents = Vector3(newMaxX, newMaxY, newMaxZ);
-
-		return destination;
-	}
-
-	ColliderAabb *ColliderAabb::Stretch(const ColliderAabb &source, const Vector3 &stretch, ColliderAabb *destination)
-	{
-		if (destination == nullptr)
-		{
-			destination = new ColliderAabb();
-		}
-
 		float newMinX, newMaxX, newMinY, newMaxY, newMinZ, newMaxZ;
 
 		if (stretch.m_x < 0.0f)
 		{
-			newMinX = source.m_minExtents.m_x + stretch.m_x;
-			newMaxX = source.m_maxExtents.m_x;
+			newMinX = m_minExtents.m_x + stretch.m_x;
+			newMaxX = m_maxExtents.m_x;
 		}
 		else
 		{
-			newMinX = source.m_minExtents.m_x;
-			newMaxX = source.m_maxExtents.m_x + stretch.m_x;
+			newMinX = m_minExtents.m_x;
+			newMaxX = m_maxExtents.m_x + stretch.m_x;
 		}
 
 		if (stretch.m_y < 0.0f)
 		{
-			newMinY = source.m_minExtents.m_y + stretch.m_y;
-			newMaxY = source.m_maxExtents.m_y;
+			newMinY = m_minExtents.m_y + stretch.m_y;
+			newMaxY = m_maxExtents.m_y;
 		}
 		else
 		{
-			newMinY = source.m_minExtents.m_y;
-			newMaxY = source.m_maxExtents.m_y + stretch.m_y;
+			newMinY = m_minExtents.m_y;
+			newMaxY = m_maxExtents.m_y + stretch.m_y;
 		}
 
 		if (stretch.m_z < 0.0f)
 		{
-			newMinZ = source.m_minExtents.m_z + stretch.m_z;
-			newMaxZ = source.m_maxExtents.m_z;
+			newMinZ = m_minExtents.m_z + stretch.m_z;
+			newMaxZ = m_maxExtents.m_z;
 		}
 		else
 		{
-			newMinZ = source.m_minExtents.m_z;
-			newMaxZ = source.m_maxExtents.m_z + stretch.m_z;
+			newMinZ = m_minExtents.m_z;
+			newMaxZ = m_maxExtents.m_z + stretch.m_z;
 		}
 
-		destination->m_minExtents = Vector3(newMinX, newMinY, newMinZ);
-		destination->m_maxExtents = Vector3(newMaxX, newMaxY, newMaxZ);
+		Vector3 minExtents = Vector3(newMinX, newMinY, newMinZ);
+		Vector3 maxExtents = Vector3(newMaxX, newMaxY, newMaxZ);
 
-		return destination;
-	}
-
-	ColliderAabb *ColliderAabb::Stretch(const ColliderAabb &source, const float &stretchX, const float &stretchY, const float &stretchZ, ColliderAabb *destination)
-	{
-		return Stretch(source, Vector3(stretchX, stretchY, stretchZ), destination);
+		return ColliderAabb(minExtents, maxExtents);
 	}
 
 	void ColliderAabb::Load(LoadedValue *value)

--- a/Sources/Physics/ColliderAabb.cpp
+++ b/Sources/Physics/ColliderAabb.cpp
@@ -363,8 +363,8 @@ namespace fl
 
 	Intersect ColliderAabb::Intersects(const Ray &ray)
 	{
-		double tmin = (m_minExtents->m_x - ray.m_origin->m_x) / ray.m_currentRay->m_x;
-		double tmax = (m_maxExtents->m_x - ray.m_origin->m_x) / ray.m_currentRay->m_x;
+		double tmin = (m_minExtents->m_x - ray.GetOrigin().m_x) / ray.GetCurrentRay().m_x;
+		double tmax = (m_maxExtents->m_x - ray.GetOrigin().m_x) / ray.GetCurrentRay().m_x;
 
 		if (tmin > tmax)
 		{
@@ -373,8 +373,8 @@ namespace fl
 			tmin = temp;
 		}
 
-		float tymin = (m_minExtents->m_y - ray.m_origin->m_y) / ray.m_currentRay->m_y;
-		float tymax = (m_maxExtents->m_y - ray.m_origin->m_y) / ray.m_currentRay->m_y;
+		float tymin = (m_minExtents->m_y - ray.GetOrigin().m_y) / ray.GetCurrentRay().m_y;
+		float tymax = (m_maxExtents->m_y - ray.GetOrigin().m_y) / ray.GetCurrentRay().m_y;
 
 		if (tymin > tymax)
 		{
@@ -398,8 +398,8 @@ namespace fl
 			tmax = tymax;
 		}
 
-		float tzmin = (m_minExtents->m_z - ray.m_origin->m_z) / ray.m_currentRay->m_z;
-		float tzmax = (m_maxExtents->m_z - ray.m_origin->m_z) / ray.m_currentRay->m_z;
+		float tzmin = (m_minExtents->m_z - ray.GetOrigin().m_z) / ray.GetCurrentRay().m_z;
+		float tzmax = (m_maxExtents->m_z - ray.GetOrigin().m_z) / ray.GetCurrentRay().m_z;
 
 		if (tzmin > tzmax)
 		{

--- a/Sources/Physics/ColliderAabb.cpp
+++ b/Sources/Physics/ColliderAabb.cpp
@@ -222,12 +222,9 @@ namespace fl
 		return destination;
 	}
 
-	Vector3 *ColliderAabb::ResolveCollision(const ICollider &other, const Vector3 &positionDelta, Vector3 *destination)
+	Vector3 ColliderAabb::ResolveCollision(const ICollider &other, const Vector3 &positionStart, const Vector3 &positionDelta)
 	{
-		if (destination == nullptr)
-		{
-			destination = new Vector3();
-		}
+		Vector3 result = Vector3();
 
 		auto aabb2 = dynamic_cast<const ColliderAabb &>(other);
 
@@ -248,7 +245,7 @@ namespace fl
 
 			if (std::fabs(newAmountX) < std::fabs(positionDelta.m_x))
 			{
-				destination->m_x = newAmountX;
+				result.m_x = newAmountX;
 			}
 		}
 
@@ -269,7 +266,7 @@ namespace fl
 
 			if (std::fabs(newAmountY) < std::fabs(positionDelta.m_y))
 			{
-				destination->m_y = newAmountY;
+				result.m_y = newAmountY;
 			}
 		}
 
@@ -290,11 +287,11 @@ namespace fl
 
 			if (std::fabs(newAmountZ) < std::fabs(positionDelta.m_z))
 			{
-				destination->m_z = newAmountZ;
+				result.m_z = newAmountZ;
 			}
 		}
 
-		return destination;
+		return result;
 	}
 
 	Intersect ColliderAabb::Intersects(const ICollider &other)

--- a/Sources/Physics/ColliderAabb.hpp
+++ b/Sources/Physics/ColliderAabb.hpp
@@ -11,20 +11,15 @@ namespace fl
 		public ICollider
 	{
 	public:
-		Vector3 *m_minExtents;
-		Vector3 *m_maxExtents;
-
-		/// <summary>
-		/// Creates a new unit aabb.
-		/// </summary>
-		ColliderAabb();
+		Vector3 m_minExtents;
+		Vector3 m_maxExtents;
 
 		/// <summary>
 		/// Creates a new aabb
 		/// </summary>
 		/// <param name="minExtents"> The aabbs min extents. </param>
 		/// <param name="minExtents"> The aabbs max extents. </param>
-		ColliderAabb(const Vector3 &minExtents, const Vector3 &maxExtents);
+		ColliderAabb(const Vector3 &minExtents = Vector3::ZERO, const Vector3 &maxExtents = Vector3::ZERO);
 
 		/// <summary>
 		/// Creates a new aabb from another aavv source.
@@ -36,13 +31,6 @@ namespace fl
 		/// Deconstructor for the aabb.
 		/// </summary>
 		~ColliderAabb();
-
-		/// <summary>
-		/// Loads from another Aabb.
-		/// </summary>
-		/// <param name="source"> The source aabb. </param>
-		/// <returns> This. </returns>
-		ColliderAabb *Set(const ColliderAabb &source);
 
 		/// <summary>
 		/// Creates a new aabb equivalent to this, scaled away from the centre origin.
@@ -169,12 +157,18 @@ namespace fl
 		/// <returns> The depth of this aabb. </returns>
 		float GetDepth() const;
 
-		Vector3 *GetMinExtents() const { return m_minExtents; }
+		Vector3 GetMinExtents() const { return m_minExtents; }
 
-		void SetMinExtents(const Vector3 &minExtents) const { *m_minExtents = minExtents; }
+		void SetMinExtents(const Vector3 &minExtents) { m_minExtents = minExtents; }
 
-		Vector3 *GetMaxExtents() const { return m_maxExtents; }
+		Vector3 GetMaxExtents() const { return m_maxExtents; }
 
-		void SetMaxExtents(const Vector3 &maxExtents) const { *m_maxExtents = maxExtents; }
+		void SetMaxExtents(const Vector3 &maxExtents) { m_maxExtents = maxExtents; }
+
+		ColliderAabb &operator=(const ColliderAabb &other);
+
+		bool operator==(const ColliderAabb &other) const;
+
+		bool operator!=(const ColliderAabb &other) const;
 	};
 }

--- a/Sources/Physics/ColliderAabb.hpp
+++ b/Sources/Physics/ColliderAabb.hpp
@@ -33,73 +33,33 @@ namespace fl
 		~ColliderAabb();
 
 		/// <summary>
-		/// Creates a new aabb equivalent to this, scaled away from the centre origin.
+		/// Scales this aabb by a scalar vector.
 		/// </summary>
-		/// <param name="source"> The source aabb. </param>
 		/// <param name="scale"> Amount to scale up the aabb. </param>
-		/// <param name="destination"> The destination aabb or null if a new aabb is to be created. </param>
-		/// <returns> A new aabb, scaled by the specified amounts. </returns>
-		static ColliderAabb *Scale(const ColliderAabb &source, const Vector3 &scale, ColliderAabb *destination);
+		/// <returns> The resultant aabb. </returns>
+		ColliderAabb Scale(const Vector3 &scale);
 
 		/// <summary>
-		/// Creates a new aabb equivalent to this, scaled away from the centre origin.
+		/// Expands this aabb away from the origin by a expansion vector.
 		/// </summary>
-		/// <param name="source"> The source aabb. </param>
-		/// <param name="scaleX"> Amount to scale up the aabb on X. </param>
-		/// <param name="scaleY"> Amount to scale up the aabb on Y. </param>
-		/// <param name="scaleZ"> Amount to scale up the aabb on Z. </param>
-		/// <param name="destination"> The destination aabb or null if a new aabb is to be created. </param>
-		/// <returns> A new aabb, scaled by the specified amounts. </returns>
-		static ColliderAabb *Scale(const ColliderAabb &source, const float &scaleX, const float &scaleY, const float &scaleZ, ColliderAabb *destination);
+		/// <param name="expandX"> Amount to scale up the aabb. </param>
+		/// <returns> The resultant aabb. </returns>
+		ColliderAabb Expand(const Vector3 &expand);
 
 		/// <summary>
-		/// Creates a new aabb equivalent to this, but scaled away from the origin by a certain amount.
-		/// </summary>
-		/// <param name="source"> The source aabb. </param>
-		/// <param name="expand"> Amount to scale up the aabb. </param>
-		/// <param name="destination"> The destination aabb or null if a new aabb is to be created. </param>
-		/// <returns> A new aabb, scaled by the specified amounts. </returns>
-		static ColliderAabb *Expand(const ColliderAabb &source, const Vector3 &expand, ColliderAabb *destination);
-
-		/// <summary>
-		/// Creates a new aabb equivalent to this, but scaled away from the origin by a certain amount.
-		/// </summary>
-		/// <param name="source"> The source aabb. </param>
-		/// <param name="expandX"> Amount to scale up the aabb on X. </param>
-		/// <param name="expandY"> Amount to scale up the aabb on Y. </param>
-		/// <param name="expandZ"> Amount to scale up the aabb on Z. </param>
-		/// <param name="destination"> The destination aabb or null if a new aabb is to be created. </param>
-		/// <returns> A new aabb, scaled by the specified amounts. </returns>
-		static ColliderAabb *Expand(const ColliderAabb &source, const float &expandX, const float &expandY, const float &expandZ, ColliderAabb *destination);
-
-		/// <summary>
-		/// Creates an aabb that bounds both this aabb and another aabb.
+		/// Combines two aabbs.
 		/// </summary>
 		/// <param name="left"> The left source aabb. </param>
 		/// <param name="right"> The right source aabb. </param>
-		/// <param name="destination"> The destination aabb or null if a new aabb is to be created. </param>
-		/// <returns> An aabb that bounds both this aabb and {@code other}. </returns>
-		static ColliderAabb *Combine(const ColliderAabb &left, const ColliderAabb &right, ColliderAabb *destination);
+		/// <returns> The resultant aabb. </returns>
+		ColliderAabb Combine(const ColliderAabb &other);
 
 		/// <summary>
-		/// Creates a new aabb equivalent to this, but stretched by a certain amount.
+		/// Stretched this aabb by a vector.
 		/// </summary>
-		/// <param name="source"> The source aabb. </param>
 		/// <param name="stretch"> The amount to stretch. </param>
-		/// <param name="destination"> The destination aabb or null if a new aabb is to be created. </param>
-		/// <returns> A new aabb, stretched by the specified amounts. </returns>
-		static ColliderAabb *Stretch(const ColliderAabb &source, const Vector3 &stretch, ColliderAabb *destination);
-
-		/// <summary>
-		/// Creates a new aabb equivalent to this, but stretched by a certain amount.
-		/// </summary>
-		/// <param name="source"> The source aabb. </param>
-		/// <param name="stretchX"> The amount to stretch on the X. </param>
-		/// <param name="stretchY"> The amount to stretch on the Y. </param>
-		/// <param name="stretchZ"> The amount to stretch on the Z. </param>
-		/// <param name="destination"> The destination aabb or null if a new aabb is to be created. </param>
-		/// <returns> A new aabb, stretched by the specified amounts. </returns>
-		static ColliderAabb *Stretch(const ColliderAabb &source, const float &stretchX, const float &stretchY, const float &stretchZ, ColliderAabb *destination);
+		/// <returns> The resultant aabb. </returns>
+		ColliderAabb Stretch(const Vector3 &stretch);
 
 		void Load(LoadedValue *value) override;
 

--- a/Sources/Physics/ColliderAabb.hpp
+++ b/Sources/Physics/ColliderAabb.hpp
@@ -107,7 +107,7 @@ namespace fl
 
 		ICollider *UpdateCollider(const Transform &transform, ICollider *destination) override;
 
-		Vector3 *ResolveCollision(const ICollider &other, const Vector3 &positionDelta, Vector3 *destination) override;
+		Vector3 ResolveCollision(const ICollider &other, const Vector3 &positionStart, const Vector3 &positionDelta) override;
 
 		Intersect Intersects(const ICollider &other) override;
 

--- a/Sources/Physics/ColliderSphere.cpp
+++ b/Sources/Physics/ColliderSphere.cpp
@@ -51,12 +51,9 @@ namespace fl
 		return source;
 	}
 
-	Vector3 *ColliderSphere::ResolveCollision(const ICollider &other, const Vector3 &positionDelta, Vector3 *destination)
+	Vector3 ColliderSphere::ResolveCollision(const ICollider &other, const Vector3 &positionStart, const Vector3 &positionDelta)
 	{
-		if (destination == nullptr)
-		{
-			destination = new Vector3();
-		}
+		Vector3 result = Vector3();
 
 		//	auto sphere2 = dynamic_cast<const ColliderSphere&>(other);
 		//	float d = sphere2.m_radius + m_radius;
@@ -66,7 +63,8 @@ namespace fl
 		//	float zDif = m_position.m_z - sphere2.m_position.m_z;
 		//	float distance = xDif * xDif + yDif * yDif + zDif * zDif;
 		// TODO: Resolve!
-		return destination;
+
+		return result;
 	}
 
 	Intersect ColliderSphere::Intersects(const ICollider &other)

--- a/Sources/Physics/ColliderSphere.cpp
+++ b/Sources/Physics/ColliderSphere.cpp
@@ -4,30 +4,22 @@
 
 namespace fl
 {
-	ColliderSphere::ColliderSphere() :
-		ICollider(),
-		m_radius(1.0f),
-		m_position(new Vector3())
-	{
-	}
-
 	ColliderSphere::ColliderSphere(const float &radius, const Vector3 &position) :
 		ICollider(),
 		m_radius(radius),
-		m_position(new Vector3(position))
+		m_position(Vector3(position))
 	{
 	}
 
 	ColliderSphere::ColliderSphere(const ColliderSphere &source) :
 		ICollider(),
 		m_radius(source.m_radius),
-		m_position(new Vector3(*source.m_position))
+		m_position(Vector3(source.m_position))
 	{
 	}
 
 	ColliderSphere::~ColliderSphere()
 	{
-		delete m_position;
 	}
 
 	void ColliderSphere::Load(LoadedValue *value)
@@ -54,7 +46,7 @@ namespace fl
 		}
 
 		source->m_radius = m_radius * transform.GetScaling().MaxComponent();
-		*source->m_position = transform.GetScaling();
+		source->m_position = transform.GetScaling();
 
 		return source;
 	}
@@ -66,12 +58,12 @@ namespace fl
 			destination = new Vector3();
 		}
 
-		//	const ColliderSphere &sphere2 = dynamic_cast<const ColliderSphere&>(other);
+		//	auto sphere2 = dynamic_cast<const ColliderSphere&>(other);
 		//	float d = sphere2.m_radius + m_radius;
 
-		//	float xDif = m_position->m_x - sphere2.m_position->m_x;
-		//	float yDif = m_position->m_y - sphere2.m_position->m_y;
-		//	float zDif = m_position->m_z - sphere2.m_position->m_z;
+		//	float xDif = m_position.m_x - sphere2.m_position.m_x;
+		//	float yDif = m_position.m_y - sphere2.m_position.m_y;
+		//	float zDif = m_position.m_z - sphere2.m_position.m_z;
 		//	float distance = xDif * xDif + yDif * yDif + zDif * zDif;
 		// TODO: Resolve!
 		return destination;
@@ -85,43 +77,43 @@ namespace fl
 
 			float distanceSquared = m_radius * m_radius;
 
-			if (m_position->x < aabb->getMinExtents()->x)
+			if (m_position.x < aabb->getMinExtents()->x)
 			{
-				distanceSquared -= pow(m_position->x - aabb->getMinExtents()->x, 2);
+				distanceSquared -= pow(m_position.x - aabb->getMinExtents()->x, 2);
 			}
-			else if (m_position->x > aabb->getMaxExtents()->x)
+			else if (m_position.x > aabb->getMaxExtents()->x)
 			{
-				distanceSquared -= pow(m_position->x - aabb->getMaxExtents()->x, 2);
-			}
-
-			if (m_position->y < aabb->getMinExtents()->x)
-			{
-				distanceSquared -= pow(m_position->y - aabb->getMinExtents()->y, 2);
-			}
-			else if (m_position->x > aabb->getMaxExtents()->x)
-			{
-				distanceSquared -= pow(m_position->y - aabb->getMaxExtents()->y, 2);
+				distanceSquared -= pow(m_position.x - aabb->getMaxExtents()->x, 2);
 			}
 
-			if (m_position->z < aabb->getMinExtents()->x)
+			if (m_position.y < aabb->getMinExtents()->x)
 			{
-				distanceSquared -= pow(m_position->z - aabb->getMinExtents()->z, 2);
+				distanceSquared -= pow(m_position.y - aabb->getMinExtents()->y, 2);
 			}
-			else if (m_position->z > aabb->getMaxExtents()->x)
+			else if (m_position.x > aabb->getMaxExtents()->x)
 			{
-				distanceSquared -= pow(m_position->z - aabb->getMaxExtents()->z, 2);
+				distanceSquared -= pow(m_position.y - aabb->getMaxExtents()->y, 2);
+			}
+
+			if (m_position.z < aabb->getMinExtents()->x)
+			{
+				distanceSquared -= pow(m_position.z - aabb->getMinExtents()->z, 2);
+			}
+			else if (m_position.z > aabb->getMaxExtents()->x)
+			{
+				distanceSquared -= pow(m_position.z - aabb->getMaxExtents()->z, 2);
 			}
 
 			return new intersect(distanceSquared > 0.0f, dynamic_cast<float>(sqrt(distanceSquared)));
 		}
 		else */
-		const ColliderSphere &sphere2 = dynamic_cast<const ColliderSphere &>(other);
+		auto sphere2 = dynamic_cast<const ColliderSphere &>(other);
 
 		float d = sphere2.m_radius + m_radius;
 
-		float xDif = m_position->m_x - sphere2.m_position->m_x;
-		float yDif = m_position->m_y - sphere2.m_position->m_y;
-		float zDif = m_position->m_z - sphere2.m_position->m_z;
+		float xDif = m_position.m_x - sphere2.m_position.m_x;
+		float yDif = m_position.m_y - sphere2.m_position.m_y;
+		float zDif = m_position.m_z - sphere2.m_position.m_z;
 		float distance = xDif * xDif + yDif * yDif + zDif * zDif;
 
 		bool intersects = d * d > distance;
@@ -130,7 +122,7 @@ namespace fl
 
 	Intersect ColliderSphere::Intersects(const Ray &ray)
 	{
-		Vector3 L = ray.GetOrigin() - *m_position;
+		Vector3 L = ray.GetOrigin() - m_position;
 
 		float a = ray.GetCurrentRay().Dot(ray.GetCurrentRay());
 		float b = 2.0f * ray.GetCurrentRay().Dot(L);
@@ -186,23 +178,40 @@ namespace fl
 
 	bool ColliderSphere::InFrustum(const Frustum &frustum)
 	{
-		return frustum.SphereInFrustum(*m_position, m_radius);
+		return frustum.SphereInFrustum(m_position, m_radius);
 	}
 
 	bool ColliderSphere::Contains(const ICollider &other)
 	{
-		const ColliderSphere &sphere2 = dynamic_cast<const ColliderSphere &>(other);
+		auto sphere2 = dynamic_cast<const ColliderSphere &>(other);
 
-		return sphere2.m_position->m_x + sphere2.m_radius - 1.0f <= m_position->m_x + m_radius - 1.0f &&
-			sphere2.m_position->m_x - sphere2.m_radius + m_radius >= m_position->m_x - m_radius + 1.0f &&
-			sphere2.m_position->m_y + sphere2.m_radius - 1.0f <= m_position->m_y + m_radius - 1.0f &&
-			sphere2.m_position->m_y - sphere2.m_radius + 1.0f >= m_position->m_y - m_radius + 1.0f &&
-			sphere2.m_position->m_z + sphere2.m_radius - 1.0f <= m_position->m_z + m_radius - 1.0f &&
-			sphere2.m_position->m_z - sphere2.m_radius + 1.0f >= m_position->m_z - m_radius + 1.0f;
+		return sphere2.m_position.m_x + sphere2.m_radius - 1.0f <= m_position.m_x + m_radius - 1.0f &&
+			sphere2.m_position.m_x - sphere2.m_radius + m_radius >= m_position.m_x - m_radius + 1.0f &&
+			sphere2.m_position.m_y + sphere2.m_radius - 1.0f <= m_position.m_y + m_radius - 1.0f &&
+			sphere2.m_position.m_y - sphere2.m_radius + 1.0f >= m_position.m_y - m_radius + 1.0f &&
+			sphere2.m_position.m_z + sphere2.m_radius - 1.0f <= m_position.m_z + m_radius - 1.0f &&
+			sphere2.m_position.m_z - sphere2.m_radius + 1.0f >= m_position.m_z - m_radius + 1.0f;
 	}
 
 	bool ColliderSphere::Contains(const Vector3 &point)
 	{
-		return m_position->DistanceSquared(point) <= m_radius * m_radius;
+		return m_position.DistanceSquared(point) <= m_radius * m_radius;
+	}
+
+	ColliderSphere &ColliderSphere::operator=(const ColliderSphere &other)
+	{
+		m_radius = other.m_radius;
+		m_position = other.m_position;
+		return *this;
+	}
+
+	bool ColliderSphere::operator==(const ColliderSphere &other) const
+	{
+		return m_radius == other.m_radius && m_position == other.m_position;
+	}
+
+	bool ColliderSphere::operator!=(const ColliderSphere &other) const
+	{
+		return !(*this == other);
 	}
 }

--- a/Sources/Physics/ColliderSphere.cpp
+++ b/Sources/Physics/ColliderSphere.cpp
@@ -130,10 +130,10 @@ namespace fl
 
 	Intersect ColliderSphere::Intersects(const Ray &ray)
 	{
-		Vector3 L = *ray.m_origin - *m_position;
+		Vector3 L = ray.GetOrigin() - *m_position;
 
-		float a = ray.m_currentRay->Dot(*ray.m_currentRay);
-		float b = 2.0f * ray.m_currentRay->Dot(L);
+		float a = ray.GetCurrentRay().Dot(ray.GetCurrentRay());
+		float b = 2.0f * ray.GetCurrentRay().Dot(L);
 		float c = L.Dot(L) - (m_radius * m_radius);
 
 		float disc = b * b - 4.0f * a * c;

--- a/Sources/Physics/ColliderSphere.cpp
+++ b/Sources/Physics/ColliderSphere.cpp
@@ -53,8 +53,8 @@ namespace fl
 			source = new ColliderSphere();
 		}
 
-		source->m_radius = m_radius * transform.GetScaling()->m_x;
-		*source->m_position = *transform.GetScaling();
+		source->m_radius = m_radius * transform.GetScaling().MaxComponent();
+		*source->m_position = transform.GetScaling();
 
 		return source;
 	}

--- a/Sources/Physics/ColliderSphere.hpp
+++ b/Sources/Physics/ColliderSphere.hpp
@@ -24,7 +24,7 @@ namespace fl
 		/// </summary>
 		/// <param name="radius"> The spheres radius. </param>
 		/// <param name="position"> The spheres initial position. </param>
-		ColliderSphere(const float &radius, const Vector3 &position = Vector3());
+		ColliderSphere(const float &radius, const Vector3 &position = Vector3::ZERO);
 
 		/// <summary>
 		/// Creates a new sphere from another sphere source.

--- a/Sources/Physics/ColliderSphere.hpp
+++ b/Sources/Physics/ColliderSphere.hpp
@@ -38,7 +38,7 @@ namespace fl
 
 		ICollider *UpdateCollider(const Transform &transform, ICollider *destination) override;
 
-		Vector3 *ResolveCollision(const ICollider &other, const Vector3 &positionDelta, Vector3 *destination) override;
+		Vector3 ResolveCollision(const ICollider &other, const Vector3 &positionStart, const Vector3 &positionDelta) override;
 
 		Intersect Intersects(const ICollider &other) override;
 

--- a/Sources/Physics/ColliderSphere.hpp
+++ b/Sources/Physics/ColliderSphere.hpp
@@ -12,19 +12,14 @@ namespace fl
 	{
 	public:
 		float m_radius;
-		Vector3 *m_position;
-
-		/// <summary>
-		/// Creates a new unit sphere
-		/// </summary>
-		ColliderSphere();
+		Vector3 m_position;
 
 		/// <summary>
 		/// Creates a new sphere
 		/// </summary>
 		/// <param name="radius"> The spheres radius. </param>
 		/// <param name="position"> The spheres initial position. </param>
-		ColliderSphere(const float &radius, const Vector3 &position = Vector3::ZERO);
+		ColliderSphere(const float &radius = 0.0f, const Vector3 &position = Vector3::ZERO);
 
 		/// <summary>
 		/// Creates a new sphere from another sphere source.
@@ -61,8 +56,14 @@ namespace fl
 
 		void SetRadius(const float &radius) { m_radius = radius; }
 
-		Vector3 *GetPosition() const { return m_position; }
+		Vector3 GetPosition() const { return m_position; }
 
-		void SetPosition(const Vector3 &position) const { *m_position = position; }
+		void SetPosition(const Vector3 &position) { m_position = position; }
+
+		ColliderSphere &operator=(const ColliderSphere &other);
+
+		bool operator==(const ColliderSphere &other) const;
+
+		bool operator!=(const ColliderSphere &other) const;
 	};
 }

--- a/Sources/Physics/Frustum.cpp
+++ b/Sources/Physics/Frustum.cpp
@@ -1,5 +1,6 @@
 #include "Frustum.hpp"
 
+#include <array>
 #include <cmath>
 #include "Helpers/SquareArray.hpp"
 

--- a/Sources/Physics/Frustum.cpp
+++ b/Sources/Physics/Frustum.cpp
@@ -22,9 +22,9 @@ namespace fl
 
 	void Frustum::Update(const Matrix4 &viewMatrix, const Matrix4 &projectionMatrix) const
 	{
-		float *view = viewMatrix.ToArray();
-		float *proj = projectionMatrix.ToArray();
-		float *clip = new float[16];
+		auto view = viewMatrix.m_linear;
+		auto proj = projectionMatrix.m_linear;
+		auto clip = std::array<float, 16>();
 
 		clip[0] = view[0] * proj[0] + view[1] * proj[4] + view[2] * proj[8] + view[3] * proj[12];
 		clip[1] = view[0] * proj[1] + view[1] * proj[5] + view[2] * proj[9] + view[3] * proj[13];
@@ -93,11 +93,6 @@ namespace fl
 		m_frustumArray[FRUSTUM_FRONT][FRUSTUM_D] = clip[15] - clip[14];
 
 		NormalizePlane(FRUSTUM_FRONT);
-
-		// Deletes the arrays used to update the frustum.
-		delete[] view;
-		delete[] proj;
-		delete[] clip;
 	}
 
 	bool Frustum::PointInFrustum(const Vector3 &position) const

--- a/Sources/Physics/Frustum.hpp
+++ b/Sources/Physics/Frustum.hpp
@@ -28,7 +28,7 @@ namespace fl
 	class FL_EXPORT Frustum
 	{
 	private:
-		float **m_frustumArray;
+		float **m_frustumArray; // TODO: Move to using a `std::array` instead.
 	public:
 		/// <summary>
 		/// Creates a new frustum.

--- a/Sources/Physics/ICollider.hpp
+++ b/Sources/Physics/ICollider.hpp
@@ -54,10 +54,10 @@ namespace fl
 		/// even if it won't necessarily intersect it after the movement specified by {@code moveDelta}.
 		/// </summary>
 		/// <param name="other"> The right source collider. </param>
+		/// <param name="positionStart"> Where the collider starts at.. </param>
 		/// <param name="positionDelta"> The delta movement for the left collider. </param>
-		/// <param name="destination"> Where the final resolved delta should be stored. </param>
-		/// <returns> The new, adjusted verifyMove delta that guarantees no intersection. </returns>
-		virtual Vector3 *ResolveCollision(const ICollider &other, const Vector3 &positionDelta, Vector3 *destination) = 0;
+		/// <returns> The new, adjusted delta that guarantees no intersection. </returns>
+		virtual Vector3 ResolveCollision(const ICollider &other, const Vector3 &positionStart, const Vector3 &positionDelta) = 0;
 
 		/// <summary>
 		/// Tests whether a shape is intersecting this shape.
@@ -93,39 +93,5 @@ namespace fl
 		/// <param name="point"> The point to check if it is contained. </param>
 		/// <returns> If the point is contained in this shape. </returns>
 		virtual bool Contains(const Vector3 &point) = 0;
-
-		/*/// <summary>
-		/// Gets the (optional) model to be used in the <seealso cref="BoundingRenderer"/>.
-		/// </summary>
-		/// <returns> A model that can be used to render this shape. </returns>
-		virtual std::shared_ptr<Model> GetRenderModel() = 0;
-
-		/// <summary>
-		/// Gets the centre for the rendered model.
-		/// </summary>
-		/// <param name="destination"> The destination for the information. </param>
-		/// <returns> The centre for the rendered model. </returns>
-		virtual Vector3 *GetRenderCentre(Vector3 *destination) = 0;
-
-		/// <summary>
-		/// Gets the rotation for the rendered model.
-		/// </summary>
-		/// <param name="destination"> The destination for the information. </param>
-		/// <returns> The rotation for the rendered model. </returns>
-		virtual Vector3 *GetRenderRotation(Vector3 *destination) = 0;
-
-		/// <summary>
-		/// Gets the scale for the rendered model.
-		/// </summary>
-		/// <param name="destination"> The destination for the information. </param>
-		/// <returns> The scale for the rendered model. </returns>
-		virtual Vector3 *GetRenderScale(Vector3 *destination) = 0;
-
-		/// <summary>
-		/// Gets the colour for the rendered model.
-		/// </summary>
-		/// <param name="destination"> The destination for the information. </param>
-		/// <returns> The colour for the rendered model. </returns>
-		virtual Colour *GetRenderColour(Colour *destination) = 0;*/
 	};
 }

--- a/Sources/Physics/ICollider.hpp
+++ b/Sources/Physics/ICollider.hpp
@@ -98,7 +98,7 @@ namespace fl
 		/// Gets the (optional) model to be used in the <seealso cref="BoundingRenderer"/>.
 		/// </summary>
 		/// <returns> A model that can be used to render this shape. </returns>
-		virtual Model *GetRenderModel() = 0;
+		virtual std::shared_ptr<Model> GetRenderModel() = 0;
 
 		/// <summary>
 		/// Gets the centre for the rendered model.

--- a/Sources/Physics/Ray.cpp
+++ b/Sources/Physics/Ray.cpp
@@ -4,42 +4,27 @@ namespace fl
 {
 	Ray::Ray(const bool &useMouse, const Vector2 &screenStart) :
 		m_useMouse(useMouse),
-		m_screenStart(new Vector2(screenStart)),
-		m_viewMatrix(new Matrix4()),
-		m_projectionMatrix(new Matrix4()),
-		m_normalizedCoords(new Vector2()),
-		m_clipCoords(new Vector4()),
-		m_eyeCoords(new Vector4()),
-		m_invertedProjection(new Matrix4()),
-		m_invertedView(new Matrix4()),
-		m_rayWorld(new Vector4()),
-		m_origin(new Vector3()),
-		m_currentRay(new Vector3())
+		m_screenStart(Vector2(screenStart)),
+		m_viewMatrix(Matrix4()),
+		m_projectionMatrix(Matrix4()),
+		m_normalizedCoords(Vector2()),
+		m_clipCoords(Vector4()),
+		m_eyeCoords(Vector4()),
+		m_invertedProjection(Matrix4()),
+		m_invertedView(Matrix4()),
+		m_rayWorld(Vector4()),
+		m_origin(Vector3()),
+		m_currentRay(Vector3())
 	{
 	}
 
 	Ray::~Ray()
 	{
-		delete m_screenStart;
-
-		delete m_origin;
-		delete m_currentRay;
-
-		delete m_viewMatrix;
-		delete m_projectionMatrix;
-
-		delete m_normalizedCoords;
-		delete m_clipCoords;
-		delete m_eyeCoords;
-
-		delete m_invertedProjection;
-		delete m_invertedView;
-		delete m_rayWorld;
 	}
 
 	void Ray::Update(const Vector3 &currentPosition, const Vector2 &mousePosition, const Matrix4 &viewMatrix, const Matrix4 &projectionMatrix)
 	{
-		*m_origin = currentPosition;
+		m_origin = currentPosition;
 
 		if (m_useMouse)
 		{
@@ -47,34 +32,27 @@ namespace fl
 		}
 		else
 		{
-			if (m_screenStart != nullptr)
-			{
-				*m_normalizedCoords = *m_screenStart;
-			}
-			else
-			{
-				*m_normalizedCoords = Vector2::ZERO;
-			}
+			m_normalizedCoords = m_screenStart;
 		}
 
-		*m_viewMatrix = viewMatrix;
-		*m_projectionMatrix = projectionMatrix;
-		*m_clipCoords = Vector4(m_normalizedCoords->m_x, m_normalizedCoords->m_y, -1.0f, 1.0f);
+		m_viewMatrix = viewMatrix;
+		m_projectionMatrix = projectionMatrix;
+		m_clipCoords = Vector4(m_normalizedCoords.m_x, m_normalizedCoords.m_y, -1.0f, 1.0f);
 		UpdateEyeCoords();
 		UpdateWorldCoords();
 	}
 
 	Vector3 Ray::GetPointOnRay(const float &distance) const
 	{
-		Vector3 vector = Vector3(distance * *m_currentRay);
-		return *m_origin + vector;
+		Vector3 vector = Vector3(distance * m_currentRay);
+		return m_origin + vector;
 	}
 
 	Vector3 Ray::ConvertToScreenSpace(const Vector3 &position) const
 	{
 		Vector4 coords = Vector4(position);
-		coords = m_viewMatrix->Transform(coords);
-		coords = m_projectionMatrix->Transform(coords);
+		coords = m_viewMatrix.Transform(coords);
+		coords = m_projectionMatrix.Transform(coords);
 
 		if (coords.m_w < 0.0f)
 		{
@@ -88,21 +66,21 @@ namespace fl
 
 	void Ray::UpdateNormalisedDeviceCoordinates(const float &mouseX, const float &mouseY)
 	{
-		m_normalizedCoords->m_x = (2.0f * mouseX) - 1.0f;
-		m_normalizedCoords->m_y = (2.0f * mouseY) - 1.0f;
+		m_normalizedCoords.m_x = (2.0f * mouseX) - 1.0f;
+		m_normalizedCoords.m_y = (2.0f * mouseY) - 1.0f;
 	}
 
 	void Ray::UpdateEyeCoords()
 	{
-		*m_invertedProjection = m_projectionMatrix->Invert();
-		*m_eyeCoords = m_invertedProjection->Transform(*m_clipCoords);
-		*m_eyeCoords = Vector4(m_eyeCoords->m_x, m_eyeCoords->m_y, -1.0f, 0.0f);
+		m_invertedProjection = m_projectionMatrix.Invert();
+		m_eyeCoords = m_invertedProjection.Transform(m_clipCoords);
+		m_eyeCoords = Vector4(m_eyeCoords.m_x, m_eyeCoords.m_y, -1.0f, 0.0f);
 	}
 
 	void Ray::UpdateWorldCoords()
 	{
-		*m_invertedView = m_viewMatrix->Invert();
-		*m_rayWorld = m_invertedView->Transform(*m_eyeCoords);
-		*m_currentRay = *m_rayWorld;
+		m_invertedView = m_viewMatrix.Invert();
+		m_rayWorld = m_invertedView.Transform(m_eyeCoords);
+		m_currentRay = m_rayWorld;
 	}
 }

--- a/Sources/Physics/Ray.hpp
+++ b/Sources/Physics/Ray.hpp
@@ -14,22 +14,22 @@ namespace fl
 	{
 	private:
 		bool m_useMouse;
-		Vector2 *m_screenStart;
+		Vector2 m_screenStart;
 
-		Matrix4 *m_viewMatrix;
-		Matrix4 *m_projectionMatrix;
+		Matrix4 m_viewMatrix;
+		Matrix4 m_projectionMatrix;
 
-		Vector2 *m_normalizedCoords;
-		Vector4 *m_clipCoords;
-		Vector4 *m_eyeCoords;
+		Vector2 m_normalizedCoords;
+		Vector4 m_clipCoords;
+		Vector4 m_eyeCoords;
 
-		Matrix4 *m_invertedProjection;
-		Matrix4 *m_invertedView;
-		Vector4 *m_rayWorld;
+		Matrix4 m_invertedProjection;
+		Matrix4 m_invertedView;
+		Vector4 m_rayWorld;
+
+		Vector3 m_origin;
+		Vector3 m_currentRay;
 	public:
-		Vector3 *m_origin;
-		Vector3 *m_currentRay;
-
 		/// <summary>
 		/// Creates a new 3D ray.
 		/// </summary>
@@ -65,6 +65,9 @@ namespace fl
 		/// <returns> Returns the destination vector X and Y being screen space coords and Z being the distance to the camera. </returns>
 		Vector3 ConvertToScreenSpace(const Vector3 &position) const;
 
+		Vector3 GetOrigin() const { return m_origin; }
+
+		Vector3 GetCurrentRay() const { return m_currentRay; }
 	private:
 		void UpdateNormalisedDeviceCoordinates(const float &mouseX, const float &mouseY);
 

--- a/Sources/Physics/Rigidbody.cpp
+++ b/Sources/Physics/Rigidbody.cpp
@@ -79,8 +79,7 @@ namespace fl
 		}
 
 		// Calculates the range in where there can be collisions.
-		ColliderAabb collisionRange = ColliderAabb();
-		ColliderAabb::Stretch(aabb1, amount, &collisionRange);
+		ColliderAabb collisionRange = aabb1.Stretch(amount);
 
 		auto rigidbodyList = Scenes::Get()->GetStructure()->QueryComponents<Rigidbody>();
 

--- a/Sources/Physics/Rigidbody.cpp
+++ b/Sources/Physics/Rigidbody.cpp
@@ -82,13 +82,12 @@ namespace fl
 		ColliderAabb collisionRange = ColliderAabb();
 		ColliderAabb::Stretch(aabb1, amount, &collisionRange);
 
-		std::vector<Rigidbody *> rigidbodys = std::vector<Rigidbody *>();
-		Scenes::Get()->GetStructure()->QueryComponents<Rigidbody>(&rigidbodys);
+		auto rigidbodyList = Scenes::Get()->GetStructure()->QueryComponents<Rigidbody>();
 
 		Vector3 currentPosition = GetGameObject()->GetTransform()->GetPosition();
 
 		// Goes though all entities in the collision range.
-		for (auto rigidbody : rigidbodys)
+		for (auto rigidbody : rigidbodyList)
 		{
 			// Ignores the original entity.
 			if (rigidbody->GetGameObject() == GetGameObject())

--- a/Sources/Physics/Rigidbody.cpp
+++ b/Sources/Physics/Rigidbody.cpp
@@ -11,16 +11,14 @@ namespace fl
 		m_mass(mass),
 		m_drag(drag),
 		m_useGravity(useGravity),
-		m_freezePosition(new Constraint3(freezePosition)),
-		m_freezeRotation(new Constraint3(freezeRotation)),
+		m_freezePosition(freezePosition),
+		m_freezeRotation(freezeRotation),
 		m_colliderCopy(nullptr)
 	{
 	}
 
 	Rigidbody::~Rigidbody()
 	{
-		delete m_freezePosition;
-		delete m_freezeRotation;
 		delete m_colliderCopy;
 	}
 
@@ -39,8 +37,8 @@ namespace fl
 		m_mass = value->GetChild("Mass")->Get<float>();
 		m_drag = value->GetChild("Drag")->Get<float>();
 		m_useGravity = value->GetChild("Use Gravity")->Get<bool>();
-		*m_freezePosition = value->GetChild("Freeze Position");
-		*m_freezeRotation = value->GetChild("Freeze Rotation");
+		m_freezePosition = value->GetChild("Freeze Position");
+		m_freezeRotation = value->GetChild("Freeze Rotation");
 	}
 
 	void Rigidbody::Write(LoadedValue *value)
@@ -48,8 +46,8 @@ namespace fl
 		value->GetChild("Mass", true)->Set(m_mass);
 		value->GetChild("Drag", true)->Set(m_drag);
 		value->GetChild("Use Gravity", true)->Set(m_useGravity);
-		m_freezePosition->Write(value->GetChild("Freeze Position", true));
-		m_freezeRotation->Write(value->GetChild("Freeze Rotation", true));
+		m_freezePosition.Write(value->GetChild("Freeze Position", true));
+		m_freezeRotation.Write(value->GetChild("Freeze Rotation", true));
 	}
 
 	Vector3 Rigidbody::ResolveCollisions(const Vector3 &amount)
@@ -87,6 +85,8 @@ namespace fl
 		std::vector<Rigidbody *> rigidbodys = std::vector<Rigidbody *>();
 		Scenes::Get()->GetStructure()->QueryComponents<Rigidbody>(&rigidbodys);
 
+		Vector3 currentPosition = GetGameObject()->GetTransform()->GetPosition();
+
 		// Goes though all entities in the collision range.
 		for (auto rigidbody : rigidbodys)
 		{
@@ -99,7 +99,7 @@ namespace fl
 			// If the main collider intersects with the other entities general collider.
 			if (rigidbody->m_colliderCopy->Intersects(collisionRange).IsIntersection())
 			{
-				rigidbody->m_colliderCopy->ResolveCollision(*m_colliderCopy, result, &result);
+				result = rigidbody->m_colliderCopy->ResolveCollision(*m_colliderCopy, currentPosition, result);
 			}
 		}
 

--- a/Sources/Physics/Rigidbody.cpp
+++ b/Sources/Physics/Rigidbody.cpp
@@ -71,9 +71,9 @@ namespace fl
 		}
 		else if (dynamic_cast<ColliderSphere *>(m_colliderCopy) != nullptr)
 		{
-			const float radius = dynamic_cast<ColliderSphere *>(m_colliderCopy)->GetRadius();
-			const Vector3 *pos = dynamic_cast<ColliderSphere *>(m_colliderCopy)->GetPosition();
-			aabb1 = ColliderAabb(-radius + *pos, radius + *pos);
+			float radius = dynamic_cast<ColliderSphere *>(m_colliderCopy)->GetRadius();
+			Vector3 pos = dynamic_cast<ColliderSphere *>(m_colliderCopy)->GetPosition();
+			aabb1 = ColliderAabb(-radius + pos, radius + pos);
 		}
 		else
 		{

--- a/Sources/Physics/Rigidbody.hpp
+++ b/Sources/Physics/Rigidbody.hpp
@@ -15,8 +15,8 @@ namespace fl
 		float m_mass;
 		float m_drag;
 		bool m_useGravity;
-		Constraint3 *m_freezePosition;
-		Constraint3 *m_freezeRotation;
+		Constraint3 m_freezePosition;
+		Constraint3 m_freezeRotation;
 		ICollider *m_colliderCopy;
 	public:
 		Rigidbody(const float &mass = 1.0f, const float &drag = 0.0f, const bool &useGravity = true,
@@ -46,13 +46,13 @@ namespace fl
 
 		void SetUseGravity(const bool &useGravity) { m_useGravity = useGravity; }
 
-		Constraint3 *GetFreezePosition() const { return m_freezePosition; }
+		Constraint3 GetFreezePosition() const { return m_freezePosition; }
 
-		void SetFreezePosition(const Constraint3 &freezePosition) const { *m_freezePosition = freezePosition; }
+		void SetFreezePosition(const Constraint3 &freezePosition) { m_freezePosition = freezePosition; }
 
-		Constraint3 *GetFreezeRotation() const { return m_freezeRotation; }
+		Constraint3 GetFreezeRotation() const { return m_freezeRotation; }
 
-		void SetFreezeRotation(const Constraint3 &freezeRotation) const { *m_freezeRotation = freezeRotation; }
+		void SetFreezeRotation(const Constraint3 &freezeRotation) { m_freezeRotation = freezeRotation; }
 
 		ICollider *GetCollider() const { return m_colliderCopy; }
 	};

--- a/Sources/Post/Deferred/RendererDeferred.cpp
+++ b/Sources/Post/Deferred/RendererDeferred.cpp
@@ -10,9 +10,9 @@
 
 namespace fl
 {
-#define MAX_LIGHTS 64
+	const int RendererDeferred::MAX_LIGHTS = 64;
 
-	struct DeferredLight
+	struct DeferredLight // TODO: Replace struct with actual light object.
 	{
 		Colour colour;
 		Vector3 position;
@@ -35,13 +35,12 @@ namespace fl
 		delete m_descriptorSet;
 		delete m_uniformScene;
 		delete m_pipeline;
-		delete m_model;
 	}
 
 	void RendererDeferred::Render(const CommandBuffer &commandBuffer, const Vector4 &clipPlane, const ICamera &camera)
 	{
 		auto skyboxRender = Scenes::Get()->GetStructure()->GetComponent<MaterialSkybox>();
-		Cubemap *environment = (skyboxRender == nullptr) ? nullptr : skyboxRender->GetCubemap();
+		auto environment = (skyboxRender == nullptr) ? nullptr : skyboxRender->GetCubemap();
 
 		// Updates uniforms.
 		std::vector<DeferredLight> sceneLights = {};
@@ -60,14 +59,14 @@ namespace fl
 				//		continue;
 				//	}
 
-				if (light->GetColour()->LengthSquared() == 0.0f)
+				if (light->GetColour().LengthSquared() == 0.0f)
 				{
 					continue;
 				}
 
 				DeferredLight lightObject = {};
-				lightObject.colour = *light->GetColour();
-				lightObject.position = *light->GetPosition();
+				lightObject.colour = light->GetColour();
+				lightObject.position = light->GetPosition();
 				lightObject.radius = light->GetRadius();
 				sceneLights.push_back(lightObject);
 			}
@@ -85,7 +84,7 @@ namespace fl
 		m_uniformScene->Push("projection", *camera.GetProjectionMatrix());
 		m_uniformScene->Push("view", *camera.GetViewMatrix());
 		m_uniformScene->Push("shadowSpace", *Shadows::Get()->GetShadowBox()->GetToShadowMapSpaceMatrix());
-		m_uniformScene->Push("fogColour", *Worlds::Get()->GetFog()->GetColour());
+		m_uniformScene->Push("fogColour", Worlds::Get()->GetFog()->GetColour());
 		m_uniformScene->Push("cameraPosition", *Scenes::Get()->GetCamera()->GetPosition());
 		m_uniformScene->Push("fogDensity", Worlds::Get()->GetFog()->GetDensity());
 		m_uniformScene->Push("fogGradient", Worlds::Get()->GetFog()->GetGradient());

--- a/Sources/Post/Deferred/RendererDeferred.cpp
+++ b/Sources/Post/Deferred/RendererDeferred.cpp
@@ -42,7 +42,9 @@ namespace fl
 		// Updates uniforms.
 		std::vector<DeferredLight> sceneLights = {};
 
-		for (auto entity : *Scenes::Get()->GetStructure()->GetAll())
+		auto gameObjects = Scenes::Get()->GetStructure()->GetAll();
+
+		for (auto entity : gameObjects)
 		{
 			auto light = entity->GetComponent<Light>();
 
@@ -65,7 +67,7 @@ namespace fl
 				lightObject.colour = light->GetColour();
 				lightObject.position = light->GetPosition();
 				lightObject.radius = light->GetRadius();
-				sceneLights.push_back(lightObject);
+				sceneLights.emplace_back(lightObject);
 			}
 
 			if (sceneLights.size() >= MAX_LIGHTS)
@@ -111,7 +113,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Deferred/RendererDeferred.cpp
+++ b/Sources/Post/Deferred/RendererDeferred.cpp
@@ -101,9 +101,9 @@ namespace fl
 		m_descriptorSet.Push("samplerShadows", m_pipeline.GetTexture(0, 0));
 		m_descriptorSet.Push("samplerBrdflut", m_brdflut);
 		m_descriptorSet.Push("samplerEnvironment", environment);
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Deferred/RendererDeferred.cpp
+++ b/Sources/Post/Deferred/RendererDeferred.cpp
@@ -84,10 +84,10 @@ namespace fl
 		m_uniformScene->Push("projection", camera.GetProjectionMatrix());
 		m_uniformScene->Push("view", camera.GetViewMatrix());
 		m_uniformScene->Push("shadowSpace", Shadows::Get()->GetShadowBox().GetToShadowMapSpaceMatrix());
-		m_uniformScene->Push("fogColour", Worlds::Get()->GetFog()->GetColour());
+		m_uniformScene->Push("fogColour", Worlds::Get()->GetFog().GetColour());
 		m_uniformScene->Push("cameraPosition", camera.GetPosition());
-		m_uniformScene->Push("fogDensity", Worlds::Get()->GetFog()->GetDensity());
-		m_uniformScene->Push("fogGradient", Worlds::Get()->GetFog()->GetGradient());
+		m_uniformScene->Push("fogDensity", Worlds::Get()->GetFog().GetDensity());
+		m_uniformScene->Push("fogGradient", Worlds::Get()->GetFog().GetGradient());
 		m_uniformScene->Push("shadowDistance", Shadows::Get()->GetShadowBoxDistance());
 		m_uniformScene->Push("shadowTransition", Shadows::Get()->GetShadowTransition());
 		m_uniformScene->Push("shadowBias", Shadows::Get()->GetShadowBias());

--- a/Sources/Post/Deferred/RendererDeferred.cpp
+++ b/Sources/Post/Deferred/RendererDeferred.cpp
@@ -21,9 +21,9 @@ namespace fl
 
 	RendererDeferred::RendererDeferred(const GraphicsStage &graphicsStage) :
 		IRenderer(),
-		m_descriptorSet(new DescriptorsHandler()),
-		m_uniformScene(new UniformHandler()),
-		m_pipeline(new Pipeline(graphicsStage, PipelineCreate({"Resources/Shaders/Deferred/Deferred.vert", "Resources/Shaders/Deferred/Deferred.frag"},
+		m_descriptorSet(DescriptorsHandler()),
+		m_uniformScene(UniformHandler()),
+		m_pipeline(Pipeline(graphicsStage, PipelineCreate({"Resources/Shaders/Deferred/Deferred.vert", "Resources/Shaders/Deferred/Deferred.frag"},
 			VertexModel::GetVertexInput(), PIPELINE_MODE_POLYGON_NO_DEPTH, PIPELINE_POLYGON_MODE_FILL, PIPELINE_CULL_MODE_BACK), {{"USE_IBL", "TRUE"}, {"MAX_LIGHTS", std::to_string(MAX_LIGHTS)}})),
 		m_model(ShapeRectangle::Resource(-1.0f, 1.0f)),
 		m_brdflut(Texture::Resource("Resources/BrdfLut.png"))
@@ -32,9 +32,6 @@ namespace fl
 
 	RendererDeferred::~RendererDeferred()
 	{
-		delete m_descriptorSet;
-		delete m_uniformScene;
-		delete m_pipeline;
 	}
 
 	void RendererDeferred::Render(const CommandBuffer &commandBuffer, const Vector4 &clipPlane, const ICamera &camera)
@@ -79,32 +76,32 @@ namespace fl
 
 		//	printf("Rendered Lights: %i\n", sceneLights.size());
 
-		m_uniformScene->Push("lights", *sceneLights.data());
-		m_uniformScene->Push("lightsCount", static_cast<int>(sceneLights.size()));
-		m_uniformScene->Push("projection", camera.GetProjectionMatrix());
-		m_uniformScene->Push("view", camera.GetViewMatrix());
-		m_uniformScene->Push("shadowSpace", Shadows::Get()->GetShadowBox().GetToShadowMapSpaceMatrix());
-		m_uniformScene->Push("fogColour", Worlds::Get()->GetFog().GetColour());
-		m_uniformScene->Push("cameraPosition", camera.GetPosition());
-		m_uniformScene->Push("fogDensity", Worlds::Get()->GetFog().GetDensity());
-		m_uniformScene->Push("fogGradient", Worlds::Get()->GetFog().GetGradient());
-		m_uniformScene->Push("shadowDistance", Shadows::Get()->GetShadowBoxDistance());
-		m_uniformScene->Push("shadowTransition", Shadows::Get()->GetShadowTransition());
-		m_uniformScene->Push("shadowBias", Shadows::Get()->GetShadowBias());
-		m_uniformScene->Push("shadowDarkness", Shadows::Get()->GetShadowDarkness());
-		m_uniformScene->Push("shadowPCF", Shadows::Get()->GetShadowPcf());
+		m_uniformScene.Push("lights", *sceneLights.data());
+		m_uniformScene.Push("lightsCount", static_cast<int>(sceneLights.size()));
+		m_uniformScene.Push("projection", camera.GetProjectionMatrix());
+		m_uniformScene.Push("view", camera.GetViewMatrix());
+		m_uniformScene.Push("shadowSpace", Shadows::Get()->GetShadowBox().GetToShadowMapSpaceMatrix());
+		m_uniformScene.Push("fogColour", Worlds::Get()->GetFog().GetColour());
+		m_uniformScene.Push("cameraPosition", camera.GetPosition());
+		m_uniformScene.Push("fogDensity", Worlds::Get()->GetFog().GetDensity());
+		m_uniformScene.Push("fogGradient", Worlds::Get()->GetFog().GetGradient());
+		m_uniformScene.Push("shadowDistance", Shadows::Get()->GetShadowBoxDistance());
+		m_uniformScene.Push("shadowTransition", Shadows::Get()->GetShadowTransition());
+		m_uniformScene.Push("shadowBias", Shadows::Get()->GetShadowBias());
+		m_uniformScene.Push("shadowDarkness", Shadows::Get()->GetShadowDarkness());
+		m_uniformScene.Push("shadowPCF", Shadows::Get()->GetShadowPcf());
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", m_uniformScene);
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerDepth", m_pipeline->GetDepthStencil());
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerNormal", m_pipeline->GetTexture(3));
-		m_descriptorSet->Push("samplerMaterial", m_pipeline->GetTexture(4));
-		m_descriptorSet->Push("samplerShadows", m_pipeline->GetTexture(0, 0));
-		m_descriptorSet->Push("samplerBrdflut", m_brdflut);
-		m_descriptorSet->Push("samplerEnvironment", environment);
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("UboScene", &m_uniformScene);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerDepth", m_pipeline.GetDepthStencil());
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerNormal", m_pipeline.GetTexture(3));
+		m_descriptorSet.Push("samplerMaterial", m_pipeline.GetTexture(4));
+		m_descriptorSet.Push("samplerShadows", m_pipeline.GetTexture(0, 0));
+		m_descriptorSet.Push("samplerBrdflut", m_brdflut);
+		m_descriptorSet.Push("samplerEnvironment", environment);
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -112,9 +109,9 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Deferred/RendererDeferred.cpp
+++ b/Sources/Post/Deferred/RendererDeferred.cpp
@@ -81,11 +81,11 @@ namespace fl
 
 		m_uniformScene->Push("lights", *sceneLights.data());
 		m_uniformScene->Push("lightsCount", static_cast<int>(sceneLights.size()));
-		m_uniformScene->Push("projection", *camera.GetProjectionMatrix());
-		m_uniformScene->Push("view", *camera.GetViewMatrix());
+		m_uniformScene->Push("projection", camera.GetProjectionMatrix());
+		m_uniformScene->Push("view", camera.GetViewMatrix());
 		m_uniformScene->Push("shadowSpace", *Shadows::Get()->GetShadowBox()->GetToShadowMapSpaceMatrix());
 		m_uniformScene->Push("fogColour", Worlds::Get()->GetFog()->GetColour());
-		m_uniformScene->Push("cameraPosition", *Scenes::Get()->GetCamera()->GetPosition());
+		m_uniformScene->Push("cameraPosition", camera.GetPosition());
 		m_uniformScene->Push("fogDensity", Worlds::Get()->GetFog()->GetDensity());
 		m_uniformScene->Push("fogGradient", Worlds::Get()->GetFog()->GetGradient());
 		m_uniformScene->Push("shadowDistance", Shadows::Get()->GetShadowBoxDistance());

--- a/Sources/Post/Deferred/RendererDeferred.cpp
+++ b/Sources/Post/Deferred/RendererDeferred.cpp
@@ -83,7 +83,7 @@ namespace fl
 		m_uniformScene->Push("lightsCount", static_cast<int>(sceneLights.size()));
 		m_uniformScene->Push("projection", camera.GetProjectionMatrix());
 		m_uniformScene->Push("view", camera.GetViewMatrix());
-		m_uniformScene->Push("shadowSpace", *Shadows::Get()->GetShadowBox()->GetToShadowMapSpaceMatrix());
+		m_uniformScene->Push("shadowSpace", Shadows::Get()->GetShadowBox().GetToShadowMapSpaceMatrix());
 		m_uniformScene->Push("fogColour", Worlds::Get()->GetFog()->GetColour());
 		m_uniformScene->Push("cameraPosition", camera.GetPosition());
 		m_uniformScene->Push("fogDensity", Worlds::Get()->GetFog()->GetDensity());

--- a/Sources/Post/Deferred/RendererDeferred.hpp
+++ b/Sources/Post/Deferred/RendererDeferred.hpp
@@ -15,10 +15,12 @@ namespace fl
 		UniformHandler *m_uniformScene;
 
 		Pipeline *m_pipeline;
-		Model *m_model;
+		std::shared_ptr<Model> m_model;
 
-		Texture *m_brdflut;
+		std::shared_ptr<Texture> m_brdflut;
 	public:
+		static const int MAX_LIGHTS;
+		
 		RendererDeferred(const GraphicsStage &graphicsStage);
 
 		~RendererDeferred();

--- a/Sources/Post/Deferred/RendererDeferred.hpp
+++ b/Sources/Post/Deferred/RendererDeferred.hpp
@@ -11,10 +11,10 @@ namespace fl
 		public IRenderer
 	{
 	private:
-		DescriptorsHandler *m_descriptorSet;
-		UniformHandler *m_uniformScene;
+		DescriptorsHandler m_descriptorSet;
+		UniformHandler m_uniformScene;
 
-		Pipeline *m_pipeline;
+		Pipeline m_pipeline;
 		std::shared_ptr<Model> m_model;
 
 		std::shared_ptr<Texture> m_brdflut;

--- a/Sources/Post/Filters/FilterBlurHorizontal.cpp
+++ b/Sources/Post/Filters/FilterBlurHorizontal.cpp
@@ -37,7 +37,7 @@ namespace fl
 		m_pipeline.BindPipeline(commandBuffer);
 
 		// Draws the object.
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterBlurHorizontal.cpp
+++ b/Sources/Post/Filters/FilterBlurHorizontal.cpp
@@ -4,7 +4,7 @@ namespace fl
 {
 	FilterBlurHorizontal::FilterBlurHorizontal(const GraphicsStage &graphicsStage, const float &scale) :
 		IPostFilter({"Resources/Shaders/Filters/Default.vert", "Resources/Shaders/Filters/BlurHorizontal.frag"}, graphicsStage, {}),
-		m_uniformScene(new UniformHandler()),
+		m_uniformScene(UniformHandler()),
 		m_scale(scale),
 		m_width(0.0f)
 	{
@@ -12,7 +12,6 @@ namespace fl
 
 	FilterBlurHorizontal::~FilterBlurHorizontal()
 	{
-		delete m_uniformScene;
 	}
 
 	void FilterBlurHorizontal::Render(const CommandBuffer &commandBuffer)
@@ -20,14 +19,14 @@ namespace fl
 		m_width = Display::Get()->GetHeight();
 
 		// Updates uniforms.
-		m_uniformScene->Push("width", m_width);
-		m_uniformScene->Push("scale", m_scale);
+		m_uniformScene.Push("width", m_width);
+		m_uniformScene.Push("scale", m_scale);
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", m_uniformScene);
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("UboScene", &m_uniformScene);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -35,10 +34,10 @@ namespace fl
 		}
 
 		// Binds the pipeline.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
 		// Draws the object.
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterBlurHorizontal.cpp
+++ b/Sources/Post/Filters/FilterBlurHorizontal.cpp
@@ -26,9 +26,9 @@ namespace fl
 		m_descriptorSet.Push("UboScene", &m_uniformScene);
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterBlurHorizontal.hpp
+++ b/Sources/Post/Filters/FilterBlurHorizontal.hpp
@@ -8,7 +8,7 @@ namespace fl
 		public IPostFilter
 	{
 	private:
-		UniformHandler *m_uniformScene;
+		UniformHandler m_uniformScene;
 
 		float m_scale;
 		float m_width;

--- a/Sources/Post/Filters/FilterBlurVertical.cpp
+++ b/Sources/Post/Filters/FilterBlurVertical.cpp
@@ -37,7 +37,7 @@ namespace fl
 		m_pipeline.BindPipeline(commandBuffer);
 
 		// Draws the object.
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterBlurVertical.cpp
+++ b/Sources/Post/Filters/FilterBlurVertical.cpp
@@ -4,7 +4,7 @@ namespace fl
 {
 	FilterBlurVertical::FilterBlurVertical(const GraphicsStage &graphicsStage, const float &scale) :
 		IPostFilter({"Resources/Shaders/Filters/Default.vert", "Resources/Shaders/Filters/BlurVertical.frag"}, graphicsStage, {}),
-		m_uniformScene(new UniformHandler()),
+		m_uniformScene(UniformHandler()),
 		m_scale(scale),
 		m_height(0.0f)
 	{
@@ -12,7 +12,6 @@ namespace fl
 
 	FilterBlurVertical::~FilterBlurVertical()
 	{
-		delete m_uniformScene;
 	}
 
 	void FilterBlurVertical::Render(const CommandBuffer &commandBuffer)
@@ -20,14 +19,14 @@ namespace fl
 		m_height = Display::Get()->GetHeight();
 
 		// Updates uniforms.
-		m_uniformScene->Push("height", m_height);
-		m_uniformScene->Push("scale", m_scale);
+		m_uniformScene.Push("height", m_height);
+		m_uniformScene.Push("scale", m_scale);
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", m_uniformScene);
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("UboScene", &m_uniformScene);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -35,10 +34,10 @@ namespace fl
 		}
 
 		// Binds the pipeline.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
 		// Draws the object.
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterBlurVertical.cpp
+++ b/Sources/Post/Filters/FilterBlurVertical.cpp
@@ -26,9 +26,9 @@ namespace fl
 		m_descriptorSet.Push("UboScene", &m_uniformScene);
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterBlurVertical.hpp
+++ b/Sources/Post/Filters/FilterBlurVertical.hpp
@@ -8,7 +8,7 @@ namespace fl
 		public IPostFilter
 	{
 	private:
-		UniformHandler *m_uniformScene;
+		UniformHandler m_uniformScene;
 
 		float m_scale;
 		float m_height;

--- a/Sources/Post/Filters/FilterCrt.cpp
+++ b/Sources/Post/Filters/FilterCrt.cpp
@@ -31,9 +31,9 @@ namespace fl
 		m_descriptorSet.Push("UboScene", &m_uniformScene);
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterCrt.cpp
+++ b/Sources/Post/Filters/FilterCrt.cpp
@@ -41,7 +41,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterCrt.cpp
+++ b/Sources/Post/Filters/FilterCrt.cpp
@@ -4,8 +4,8 @@ namespace fl
 {
 	FilterCrt::FilterCrt(const GraphicsStage &graphicsStage) :
 		IPostFilter({"Resources/Shaders/Filters/Default.vert", "Resources/Shaders/Filters/Crt.frag"}, graphicsStage, {}),
-		m_uniformScene(new UniformHandler()),
-		m_screenColour(new Colour(0.5f, 1.0f, 0.5f)),
+		m_uniformScene(UniformHandler()),
+		m_screenColour(Colour(0.5f, 1.0f, 0.5f)),
 		m_curveAmountX(0.1f),
 		m_curveAmountY(0.1f),
 		m_scanLineSize(1000.0f),
@@ -15,25 +15,23 @@ namespace fl
 
 	FilterCrt::~FilterCrt()
 	{
-		delete m_uniformScene;
-		delete m_screenColour;
 	}
 
 	void FilterCrt::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates uniforms.
-		m_uniformScene->Push("screenColour", *m_screenColour);
-		m_uniformScene->Push("curveAmountX", m_curveAmountX * Display::Get()->GetAspectRatio());
-		m_uniformScene->Push("curveAmountY", m_curveAmountY);
-		m_uniformScene->Push("scanLineSize", m_scanLineSize);
-		m_uniformScene->Push("scanIntensity", m_scanIntensity);
-		m_uniformScene->Push("moveTime", Engine::Get()->GetTime() / 100.0f);
+		m_uniformScene.Push("screenColour", m_screenColour);
+		m_uniformScene.Push("curveAmountX", m_curveAmountX * Display::Get()->GetAspectRatio());
+		m_uniformScene.Push("curveAmountY", m_curveAmountY);
+		m_uniformScene.Push("scanLineSize", m_scanLineSize);
+		m_uniformScene.Push("scanIntensity", m_scanIntensity);
+		m_uniformScene.Push("moveTime", Engine::Get()->GetTime() / 100.0f);
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", m_uniformScene);
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("UboScene", &m_uniformScene);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -41,9 +39,9 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterCrt.hpp
+++ b/Sources/Post/Filters/FilterCrt.hpp
@@ -9,9 +9,9 @@ namespace fl
 		public IPostFilter
 	{
 	private:
-		UniformHandler *m_uniformScene;
+		UniformHandler m_uniformScene;
 
-		Colour *m_screenColour;
+		Colour m_screenColour;
 		float m_curveAmountX;
 		float m_curveAmountY;
 		float m_scanLineSize;
@@ -23,9 +23,9 @@ namespace fl
 
 		void Render(const CommandBuffer &commandBuffer) override;
 
-		Colour *GetScreenColour() const { return m_screenColour; }
+		Colour GetScreenColour() const { return m_screenColour; }
 
-		void SetScreenColour(const Colour &screenColour) { *m_screenColour = screenColour; }
+		void SetScreenColour(const Colour &screenColour) { m_screenColour = screenColour; }
 
 		float GetCurveAmountX() const { return m_curveAmountX; }
 

--- a/Sources/Post/Filters/FilterDarken.cpp
+++ b/Sources/Post/Filters/FilterDarken.cpp
@@ -4,26 +4,25 @@ namespace fl
 {
 	FilterDarken::FilterDarken(const GraphicsStage &graphicsStage) :
 		IPostFilter({"Resources/Shaders/Filters/Default.vert", "Resources/Shaders/Filters/Darken.frag"}, graphicsStage, {}),
-		m_uniformScene(new UniformHandler()),
+		m_uniformScene(UniformHandler()),
 		m_factor(0.5f)
 	{
 	}
 
 	FilterDarken::~FilterDarken()
 	{
-		delete m_uniformScene;
 	}
 
 	void FilterDarken::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates uniforms.
-		m_uniformScene->Push("factor", m_factor);
+		m_uniformScene.Push("factor", m_factor);
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", m_uniformScene);
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("UboScene", &m_uniformScene);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -31,9 +30,9 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterDarken.cpp
+++ b/Sources/Post/Filters/FilterDarken.cpp
@@ -22,9 +22,9 @@ namespace fl
 		m_descriptorSet.Push("UboScene", &m_uniformScene);
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterDarken.cpp
+++ b/Sources/Post/Filters/FilterDarken.cpp
@@ -32,7 +32,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterDarken.hpp
+++ b/Sources/Post/Filters/FilterDarken.hpp
@@ -8,7 +8,7 @@ namespace fl
 		public IPostFilter
 	{
 	private:
-		UniformHandler *m_uniformScene;
+		UniformHandler m_uniformScene;
 
 		float m_factor;
 	public:

--- a/Sources/Post/Filters/FilterDefault.cpp
+++ b/Sources/Post/Filters/FilterDefault.cpp
@@ -14,9 +14,9 @@ namespace fl
 	void FilterDefault::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates descriptors.
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -24,9 +24,9 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterDefault.cpp
+++ b/Sources/Post/Filters/FilterDefault.cpp
@@ -16,9 +16,9 @@ namespace fl
 		// Updates descriptors.
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterDefault.cpp
+++ b/Sources/Post/Filters/FilterDefault.cpp
@@ -26,7 +26,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterEmboss.cpp
+++ b/Sources/Post/Filters/FilterEmboss.cpp
@@ -16,9 +16,9 @@ namespace fl
 		// Updates descriptors.
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterEmboss.cpp
+++ b/Sources/Post/Filters/FilterEmboss.cpp
@@ -14,9 +14,9 @@ namespace fl
 	void FilterEmboss::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates descriptors.
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -24,9 +24,9 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterEmboss.cpp
+++ b/Sources/Post/Filters/FilterEmboss.cpp
@@ -26,7 +26,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterFxaa.cpp
+++ b/Sources/Post/Filters/FilterFxaa.cpp
@@ -22,9 +22,9 @@ namespace fl
 		m_descriptorSet.Push("UboScene", &m_uniformScene);
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterFxaa.cpp
+++ b/Sources/Post/Filters/FilterFxaa.cpp
@@ -33,7 +33,7 @@ namespace fl
 		m_pipeline.BindPipeline(commandBuffer);
 
 		// Draws the object.
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterFxaa.cpp
+++ b/Sources/Post/Filters/FilterFxaa.cpp
@@ -4,26 +4,25 @@ namespace fl
 {
 	FilterFxaa::FilterFxaa(const GraphicsStage &graphicsStage) :
 		IPostFilter({"Resources/Shaders/Filters/Default.vert", "Resources/Shaders/Filters/Fxaa.frag"}, graphicsStage, {}),
-		m_uniformScene(new UniformHandler()),
+		m_uniformScene(UniformHandler()),
 		m_spanMax(8.0f)
 	{
 	}
 
 	FilterFxaa::~FilterFxaa()
 	{
-		delete m_uniformScene;
 	}
 
 	void FilterFxaa::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates uniforms.
-		m_uniformScene->Push("spanMax", m_spanMax);
+		m_uniformScene.Push("spanMax", m_spanMax);
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", m_uniformScene);
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("UboScene", &m_uniformScene);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -31,10 +30,10 @@ namespace fl
 		}
 
 		// Binds the pipeline.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
 		// Draws the object.
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterFxaa.hpp
+++ b/Sources/Post/Filters/FilterFxaa.hpp
@@ -8,7 +8,7 @@ namespace fl
 		public IPostFilter
 	{
 	private:
-		UniformHandler *m_uniformScene;
+		UniformHandler m_uniformScene;
 
 		float m_spanMax;
 	public:

--- a/Sources/Post/Filters/FilterGrain.cpp
+++ b/Sources/Post/Filters/FilterGrain.cpp
@@ -22,9 +22,9 @@ namespace fl
 		m_descriptorSet.Push("UboScene", &m_uniformScene);
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterGrain.cpp
+++ b/Sources/Post/Filters/FilterGrain.cpp
@@ -4,26 +4,25 @@ namespace fl
 {
 	FilterGrain::FilterGrain(const GraphicsStage &graphicsStage) :
 		IPostFilter({"Resources/Shaders/Filters/Default.vert", "Resources/Shaders/Filters/Grain.frag"}, graphicsStage, {}),
-		m_uniformScene(new UniformHandler()),
+		m_uniformScene(UniformHandler()),
 		m_strength(2.3f)
 	{
 	}
 
 	FilterGrain::~FilterGrain()
 	{
-		delete m_uniformScene;
 	}
 
 	void FilterGrain::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates uniforms.
-		m_uniformScene->Push("strength", m_strength);
+		m_uniformScene.Push("strength", m_strength);
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", m_uniformScene);
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("UboScene", &m_uniformScene);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -31,10 +30,10 @@ namespace fl
 		}
 
 		// Binds the pipeline.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
 		// Draws the object.
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterGrain.cpp
+++ b/Sources/Post/Filters/FilterGrain.cpp
@@ -33,7 +33,7 @@ namespace fl
 		m_pipeline.BindPipeline(commandBuffer);
 
 		// Draws the object.
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterGrain.hpp
+++ b/Sources/Post/Filters/FilterGrain.hpp
@@ -8,7 +8,7 @@ namespace fl
 		public IPostFilter
 	{
 	private:
-		UniformHandler *m_uniformScene;
+		UniformHandler m_uniformScene;
 
 		float m_strength;
 	public:

--- a/Sources/Post/Filters/FilterGrey.cpp
+++ b/Sources/Post/Filters/FilterGrey.cpp
@@ -14,9 +14,9 @@ namespace fl
 	void FilterGrey::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates descriptors.
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -24,9 +24,9 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterGrey.cpp
+++ b/Sources/Post/Filters/FilterGrey.cpp
@@ -16,9 +16,9 @@ namespace fl
 		// Updates descriptors.
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterGrey.cpp
+++ b/Sources/Post/Filters/FilterGrey.cpp
@@ -26,7 +26,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterLensflare.cpp
+++ b/Sources/Post/Filters/FilterLensflare.cpp
@@ -6,31 +6,29 @@ namespace fl
 {
 	FilterLensflare::FilterLensflare(const GraphicsStage &graphicsStage) :
 		IPostFilter({"Resources/Shaders/Filters/Default.vert", "Resources/Shaders/Filters/Lensflare.frag"}, graphicsStage, {}),
-		m_uniformScene(new UniformHandler()),
-		m_sunPosition(new Vector3()),
+		m_uniformScene(UniformHandler()),
+		m_sunPosition(Vector3()),
 		m_sunHeight(0.0f)
 	{
 	}
 
 	FilterLensflare::~FilterLensflare()
 	{
-		delete m_uniformScene;
-		delete m_sunPosition;
 	}
 
 	void FilterLensflare::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates uniforms.
-		m_uniformScene->Push("sunPosition", *m_sunPosition);
-		m_uniformScene->Push("worldHeight", m_sunHeight);
-		m_uniformScene->Push("displaySize", Vector2(static_cast<float>(Display::Get()->GetWidth()), static_cast<float>(Display::Get()->GetHeight())));
+		m_uniformScene.Push("sunPosition", m_sunPosition);
+		m_uniformScene.Push("worldHeight", m_sunHeight);
+		m_uniformScene.Push("displaySize", Vector2(static_cast<float>(Display::Get()->GetWidth()), static_cast<float>(Display::Get()->GetHeight())));
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", m_uniformScene);
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerMaterial", m_pipeline->GetTexture(4));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("UboScene", &m_uniformScene);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerMaterial", m_pipeline.GetTexture(4));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -38,15 +36,15 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 
-	void FilterLensflare::SetSunPosition(const Vector3 &sunPosition) const
+	void FilterLensflare::SetSunPosition(const Vector3 &sunPosition)
 	{
 		auto camera = Scenes::Get()->GetCamera();
-		*m_sunPosition = Matrix4::WorldToScreenSpace(sunPosition, camera->GetViewMatrix(), camera->GetProjectionMatrix());
+		m_sunPosition = Matrix4::WorldToScreenSpace(sunPosition, camera->GetViewMatrix(), camera->GetProjectionMatrix());
 	}
 }

--- a/Sources/Post/Filters/FilterLensflare.cpp
+++ b/Sources/Post/Filters/FilterLensflare.cpp
@@ -47,6 +47,6 @@ namespace fl
 	void FilterLensflare::SetSunPosition(const Vector3 &sunPosition) const
 	{
 		auto camera = Scenes::Get()->GetCamera();
-		*m_sunPosition = Matrix4::WorldToScreenSpace(sunPosition, *camera->GetViewMatrix(), *camera->GetProjectionMatrix());
+		*m_sunPosition = Matrix4::WorldToScreenSpace(sunPosition, camera->GetViewMatrix(), camera->GetProjectionMatrix());
 	}
 }

--- a/Sources/Post/Filters/FilterLensflare.cpp
+++ b/Sources/Post/Filters/FilterLensflare.cpp
@@ -28,9 +28,9 @@ namespace fl
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerMaterial", m_pipeline.GetTexture(4));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterLensflare.cpp
+++ b/Sources/Post/Filters/FilterLensflare.cpp
@@ -46,7 +46,7 @@ namespace fl
 
 	void FilterLensflare::SetSunPosition(const Vector3 &sunPosition) const
 	{
-		ICamera *camera = Scenes::Get()->GetCamera();
+		auto camera = Scenes::Get()->GetCamera();
 		*m_sunPosition = Matrix4::WorldToScreenSpace(sunPosition, *camera->GetViewMatrix(), *camera->GetProjectionMatrix());
 	}
 }

--- a/Sources/Post/Filters/FilterLensflare.cpp
+++ b/Sources/Post/Filters/FilterLensflare.cpp
@@ -38,7 +38,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 

--- a/Sources/Post/Filters/FilterLensflare.hpp
+++ b/Sources/Post/Filters/FilterLensflare.hpp
@@ -9,9 +9,9 @@ namespace fl
 		public IPostFilter
 	{
 	private:
-		UniformHandler *m_uniformScene;
+		UniformHandler m_uniformScene;
 
-		Vector3 *m_sunPosition;
+		Vector3 m_sunPosition;
 		float m_sunHeight;
 	public:
 		FilterLensflare(const GraphicsStage &graphicsStage);
@@ -20,9 +20,9 @@ namespace fl
 
 		void Render(const CommandBuffer &commandBuffer) override;
 
-		void SetSunPosition(const Vector3 &sunPosition) const;
+		Vector3 GetSunPosition() const { return m_sunPosition; }
 
-		Vector3 *GetSunPosition() const { return m_sunPosition; }
+		void SetSunPosition(const Vector3 &sunPosition);
 
 		float GetSunHeight() const { return m_sunHeight; }
 

--- a/Sources/Post/Filters/FilterNegative.cpp
+++ b/Sources/Post/Filters/FilterNegative.cpp
@@ -16,9 +16,9 @@ namespace fl
 		// Updates descriptors.
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterNegative.cpp
+++ b/Sources/Post/Filters/FilterNegative.cpp
@@ -14,9 +14,9 @@ namespace fl
 	void FilterNegative::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates descriptors.
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -24,9 +24,9 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterNegative.cpp
+++ b/Sources/Post/Filters/FilterNegative.cpp
@@ -26,7 +26,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterPixel.cpp
+++ b/Sources/Post/Filters/FilterPixel.cpp
@@ -22,9 +22,9 @@ namespace fl
 		m_descriptorSet.Push("UboScene", &m_uniformScene);
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterPixel.cpp
+++ b/Sources/Post/Filters/FilterPixel.cpp
@@ -32,7 +32,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterPixel.cpp
+++ b/Sources/Post/Filters/FilterPixel.cpp
@@ -4,26 +4,25 @@ namespace fl
 {
 	FilterPixel::FilterPixel(const GraphicsStage &graphicsStage) :
 		IPostFilter({"Resources/Shaders/Filters/Default.vert", "Resources/Shaders/Filters/Pixel.frag"}, graphicsStage, {}),
-		m_uniformScene(new UniformHandler()),
+		m_uniformScene(UniformHandler()),
 		m_pixelSize(2.0f)
 	{
 	}
 
 	FilterPixel::~FilterPixel()
 	{
-		delete m_uniformScene;
 	}
 
 	void FilterPixel::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates uniforms.
-		m_uniformScene->Push("pixelSize", m_pixelSize);
+		m_uniformScene.Push("pixelSize", m_pixelSize);
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", m_uniformScene);
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("UboScene", &m_uniformScene);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -31,9 +30,9 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterPixel.hpp
+++ b/Sources/Post/Filters/FilterPixel.hpp
@@ -8,7 +8,7 @@ namespace fl
 		public IPostFilter
 	{
 	private:
-		UniformHandler *m_uniformScene;
+		UniformHandler m_uniformScene;
 
 		float m_pixelSize;
 	public:

--- a/Sources/Post/Filters/FilterSepia.cpp
+++ b/Sources/Post/Filters/FilterSepia.cpp
@@ -14,9 +14,9 @@ namespace fl
 	void FilterSepia::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates descriptors.
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -24,9 +24,9 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterSepia.cpp
+++ b/Sources/Post/Filters/FilterSepia.cpp
@@ -16,9 +16,9 @@ namespace fl
 		// Updates descriptors.
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterSepia.cpp
+++ b/Sources/Post/Filters/FilterSepia.cpp
@@ -26,7 +26,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterTiltshift.cpp
+++ b/Sources/Post/Filters/FilterTiltshift.cpp
@@ -38,7 +38,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterTiltshift.cpp
+++ b/Sources/Post/Filters/FilterTiltshift.cpp
@@ -28,9 +28,9 @@ namespace fl
 		m_descriptorSet.Push("UboScene", &m_uniformScene);
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterTiltshift.cpp
+++ b/Sources/Post/Filters/FilterTiltshift.cpp
@@ -4,7 +4,7 @@ namespace fl
 {
 	FilterTiltshift::FilterTiltshift(const GraphicsStage &graphicsStage) :
 		IPostFilter({"Resources/Shaders/Filters/Default.vert", "Resources/Shaders/Filters/Tiltshift.frag"}, graphicsStage, {}),
-		m_uniformScene(new UniformHandler()),
+		m_uniformScene(UniformHandler()),
 		m_blurAmount(1.0f),
 		m_centre(1.1f),
 		m_stepSize(0.004f),
@@ -14,22 +14,21 @@ namespace fl
 
 	FilterTiltshift::~FilterTiltshift()
 	{
-		delete m_uniformScene;
 	}
 
 	void FilterTiltshift::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates uniforms.
-		m_uniformScene->Push("blurAmount", m_blurAmount);
-		m_uniformScene->Push("centre", m_centre);
-		m_uniformScene->Push("stepSize", m_stepSize);
-		m_uniformScene->Push("steps", m_steps);
+		m_uniformScene.Push("blurAmount", m_blurAmount);
+		m_uniformScene.Push("centre", m_centre);
+		m_uniformScene.Push("stepSize", m_stepSize);
+		m_uniformScene.Push("steps", m_steps);
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", m_uniformScene);
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("UboScene", &m_uniformScene);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -37,9 +36,9 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterTiltshift.hpp
+++ b/Sources/Post/Filters/FilterTiltshift.hpp
@@ -8,7 +8,7 @@ namespace fl
 		public IPostFilter
 	{
 	private:
-		UniformHandler *m_uniformScene;
+		UniformHandler m_uniformScene;
 
 		float m_blurAmount;
 		float m_centre;

--- a/Sources/Post/Filters/FilterTone.cpp
+++ b/Sources/Post/Filters/FilterTone.cpp
@@ -16,9 +16,9 @@ namespace fl
 		// Updates descriptors.
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterTone.cpp
+++ b/Sources/Post/Filters/FilterTone.cpp
@@ -26,7 +26,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterTone.cpp
+++ b/Sources/Post/Filters/FilterTone.cpp
@@ -14,9 +14,9 @@ namespace fl
 	void FilterTone::Render(const CommandBuffer &commandBuffer)
 	{
 		// Updates descriptors.
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -24,9 +24,9 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterWobble.cpp
+++ b/Sources/Post/Filters/FilterWobble.cpp
@@ -4,7 +4,7 @@ namespace fl
 {
 	FilterWobble::FilterWobble(const GraphicsStage &graphicsStage) :
 		IPostFilter({"Resources/Shaders/Filters/Default.vert", "Resources/Shaders/Filters/Wobble.frag"}, graphicsStage, {}),
-		m_uniformScene(new UniformHandler()),
+		m_uniformScene(UniformHandler()),
 		m_wobbleSpeed(2.0f),
 		m_wobbleAmount(0.0f)
 	{
@@ -12,7 +12,6 @@ namespace fl
 
 	FilterWobble::~FilterWobble()
 	{
-		delete m_uniformScene;
 	}
 
 	void FilterWobble::Render(const CommandBuffer &commandBuffer)
@@ -20,13 +19,13 @@ namespace fl
 		m_wobbleAmount += m_wobbleSpeed * Engine::Get()->GetDeltaRender();
 
 		// Updates uniforms.
-		m_uniformScene->Push("moveIt", m_wobbleAmount);
+		m_uniformScene.Push("moveIt", m_wobbleAmount);
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", m_uniformScene);
-		m_descriptorSet->Push("writeColour", m_pipeline->GetTexture(2));
-		m_descriptorSet->Push("samplerColour", m_pipeline->GetTexture(2));
-		bool descriptorsSet = m_descriptorSet->Update(*m_pipeline);
+		m_descriptorSet.Push("UboScene", &m_uniformScene);
+		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
+		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
+		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
 
 		if (!descriptorsSet)
 		{
@@ -34,9 +33,9 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterWobble.cpp
+++ b/Sources/Post/Filters/FilterWobble.cpp
@@ -25,9 +25,9 @@ namespace fl
 		m_descriptorSet.Push("UboScene", &m_uniformScene);
 		m_descriptorSet.Push("writeColour", m_pipeline.GetTexture(2));
 		m_descriptorSet.Push("samplerColour", m_pipeline.GetTexture(2));
-		bool descriptorsSet = m_descriptorSet.Update(m_pipeline);
+		bool updateSuccess = m_descriptorSet.Update(m_pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}

--- a/Sources/Post/Filters/FilterWobble.cpp
+++ b/Sources/Post/Filters/FilterWobble.cpp
@@ -35,7 +35,7 @@ namespace fl
 		// Draws the object.
 		m_pipeline.BindPipeline(commandBuffer);
 
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		m_model->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Post/Filters/FilterWobble.hpp
+++ b/Sources/Post/Filters/FilterWobble.hpp
@@ -8,7 +8,7 @@ namespace fl
 		public IPostFilter
 	{
 	private:
-		UniformHandler *m_uniformScene;
+		UniformHandler m_uniformScene;
 
 		float m_wobbleSpeed;
 		float m_wobbleAmount;

--- a/Sources/Post/IPostFilter.cpp
+++ b/Sources/Post/IPostFilter.cpp
@@ -5,8 +5,8 @@
 namespace fl
 {
 	IPostFilter::IPostFilter(const std::vector<std::string> &shaderStages, const GraphicsStage &graphicsStage, const std::vector<PipelineDefine> &defines) :
-		m_descriptorSet(new DescriptorsHandler()),
-		m_pipeline(new Pipeline(graphicsStage, PipelineCreate(shaderStages, VertexModel::GetVertexInput(),
+		m_descriptorSet(DescriptorsHandler()),
+		m_pipeline(Pipeline(graphicsStage, PipelineCreate(shaderStages, VertexModel::GetVertexInput(),
 			PIPELINE_MODE_POLYGON_NO_DEPTH, PIPELINE_POLYGON_MODE_FILL, PIPELINE_CULL_MODE_BACK), defines)),
 		m_model(ShapeRectangle::Resource(-1.0f, 1.0f))
 	{
@@ -14,7 +14,5 @@ namespace fl
 
 	IPostFilter::~IPostFilter()
 	{
-		delete m_descriptorSet;
-		delete m_pipeline;
 	}
 }

--- a/Sources/Post/IPostFilter.cpp
+++ b/Sources/Post/IPostFilter.cpp
@@ -16,6 +16,5 @@ namespace fl
 	{
 		delete m_descriptorSet;
 		delete m_pipeline;
-		delete m_model;
 	}
 }

--- a/Sources/Post/IPostFilter.hpp
+++ b/Sources/Post/IPostFilter.hpp
@@ -14,7 +14,7 @@ namespace fl
 		DescriptorsHandler *m_descriptorSet;
 
 		Pipeline *m_pipeline;
-		Model *m_model;
+		std::shared_ptr<Model> m_model;
 	public:
 		/// <summary>
 		/// Creates a new post effect filter
@@ -38,6 +38,6 @@ namespace fl
 
 		Pipeline *GetPipeline() const { return m_pipeline; }
 
-		Model *GetModel() const { return m_model; }
+		std::shared_ptr<Model> GetModel() const { return m_model; }
 	};
 }

--- a/Sources/Post/IPostFilter.hpp
+++ b/Sources/Post/IPostFilter.hpp
@@ -11,9 +11,9 @@ namespace fl
 	class FL_EXPORT IPostFilter
 	{
 	protected:
-		DescriptorsHandler *m_descriptorSet;
+		DescriptorsHandler m_descriptorSet;
 
-		Pipeline *m_pipeline;
+		Pipeline m_pipeline;
 		std::shared_ptr<Model> m_model;
 	public:
 		/// <summary>
@@ -34,9 +34,9 @@ namespace fl
 		/// </summary>
 		virtual void Render(const CommandBuffer &commandBuffer) = 0;
 
-		DescriptorsHandler *GetDescriptorSet() const { return m_descriptorSet; }
+		DescriptorsHandler GetDescriptorSet() const { return m_descriptorSet; }
 
-		Pipeline *GetPipeline() const { return m_pipeline; }
+		Pipeline GetPipeline() const { return m_pipeline; }
 
 		std::shared_ptr<Model> GetModel() const { return m_model; }
 	};

--- a/Sources/Post/Pipelines/PipelineGaussian.cpp
+++ b/Sources/Post/Pipelines/PipelineGaussian.cpp
@@ -3,20 +3,18 @@
 namespace fl
 {
 	PipelineGaussian::PipelineGaussian(const GraphicsStage &graphicsStage, const float &scale) :
-		m_filterBlurVertical(new FilterBlurVertical(graphicsStage, scale)),
-		m_filterBlurHorizontal(new FilterBlurHorizontal(graphicsStage, scale))
+		m_filterBlurVertical(FilterBlurVertical(graphicsStage, scale)),
+		m_filterBlurHorizontal(FilterBlurHorizontal(graphicsStage, scale))
 	{
 	}
 
 	PipelineGaussian::~PipelineGaussian()
 	{
-		delete m_filterBlurVertical;
-		delete m_filterBlurHorizontal;
 	}
 
 	void PipelineGaussian::Render(const CommandBuffer &commandBuffer)
 	{
-		m_filterBlurVertical->Render(commandBuffer);
-		m_filterBlurHorizontal->Render(commandBuffer);
+		m_filterBlurVertical.Render(commandBuffer);
+		m_filterBlurHorizontal.Render(commandBuffer);
 	}
 }

--- a/Sources/Post/Pipelines/PipelineGaussian.hpp
+++ b/Sources/Post/Pipelines/PipelineGaussian.hpp
@@ -10,8 +10,8 @@ namespace fl
 		public IPostPipeline
 	{
 	private:
-		FilterBlurVertical *m_filterBlurVertical;
-		FilterBlurHorizontal *m_filterBlurHorizontal;
+		FilterBlurVertical m_filterBlurVertical;
+		FilterBlurHorizontal m_filterBlurHorizontal;
 	public:
 		PipelineGaussian(const GraphicsStage &graphicsStage, const float &scale = 2.0f);
 

--- a/Sources/Renderer/Buffers/Buffer.cpp
+++ b/Sources/Renderer/Buffers/Buffer.cpp
@@ -15,9 +15,9 @@ namespace fl
 			return;
 		}
 
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
-		const auto surface = Display::Get()->GetVkSurface();
-		const auto indices = QueueFamily::FindQueueFamilies(surface);
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto surface = Display::Get()->GetVkSurface();
+		auto indices = QueueFamily::FindQueueFamilies(surface);
 
 		VkBufferCreateInfo bufferCreateInfo = {};
 		bufferCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
@@ -45,7 +45,7 @@ namespace fl
 
 	Buffer::~Buffer()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		vkDestroyBuffer(logicalDevice, m_buffer, nullptr);
 		vkFreeMemory(logicalDevice, m_bufferMemory, nullptr);
@@ -53,7 +53,7 @@ namespace fl
 
 	uint32_t Buffer::FindMemoryType(const uint32_t &typeFilter, const VkMemoryPropertyFlags &properties)
 	{
-		const auto physicalDevice = Display::Get()->GetVkPhysicalDevice();
+		auto physicalDevice = Display::Get()->GetVkPhysicalDevice();
 
 		VkPhysicalDeviceMemoryProperties physicalDeviceMemoryProperties;
 		vkGetPhysicalDeviceMemoryProperties(physicalDevice, &physicalDeviceMemoryProperties);
@@ -74,9 +74,9 @@ namespace fl
 
 	void Buffer::CopyBuffer(const VkBuffer srcBuffer, const VkBuffer dstBuffer, const VkDeviceSize &size)
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
-		const auto queue = Display::Get()->GetVkQueue();
-		const auto commandPool = Renderer::Get()->GetVkCommandPool();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto queue = Display::Get()->GetVkQueue();
+		auto commandPool = Renderer::Get()->GetVkCommandPool();
 
 		// Makes a temporary command buffer for the memory transfer operation.
 		VkCommandBufferAllocateInfo commandBufferAllocateInfo = {};

--- a/Sources/Renderer/Buffers/CommandBuffer.cpp
+++ b/Sources/Renderer/Buffers/CommandBuffer.cpp
@@ -8,8 +8,8 @@ namespace fl
 		m_bufferLevel(bufferLevel),
 		m_commandBuffer(VK_NULL_HANDLE)
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
-		const auto commandPool = Renderer::Get()->GetVkCommandPool();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto commandPool = Renderer::Get()->GetVkCommandPool();
 
 		VkCommandBufferAllocateInfo commandBufferAllocateInfo = {};
 		commandBufferAllocateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
@@ -27,9 +27,9 @@ namespace fl
 
 	CommandBuffer::~CommandBuffer()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
-		const auto queue = Display::Get()->GetVkQueue();
-		const auto commandPool = Renderer::Get()->GetVkCommandPool();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto queue = Display::Get()->GetVkQueue();
+		auto commandPool = Renderer::Get()->GetVkCommandPool();
 
 		Display::ErrorVk(vkEndCommandBuffer(m_commandBuffer));
 

--- a/Sources/Renderer/Buffers/IndexBuffer.cpp
+++ b/Sources/Renderer/Buffers/IndexBuffer.cpp
@@ -7,7 +7,7 @@ namespace fl
 		m_indexType(indexType),
 		m_indexCount(static_cast<uint32_t>(indexCount))
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		// Copies the index data to the buffer.
 		void *data;

--- a/Sources/Renderer/Buffers/UniformBuffer.cpp
+++ b/Sources/Renderer/Buffers/UniformBuffer.cpp
@@ -18,9 +18,9 @@ namespace fl
 
 	void UniformBuffer::Update(void *newData)
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
-		//	const auto commandBuffer = Renderer::Get()->GetCommandBuffer();
+		//	auto commandBuffer = Renderer::Get()->GetCommandBuffer();
 		//	vkCmdUpdateBuffer(commandBuffer, m_buffer, 0, m_size, newData);
 
 		// Copies the data to the buffer.

--- a/Sources/Renderer/Buffers/VertexBuffer.cpp
+++ b/Sources/Renderer/Buffers/VertexBuffer.cpp
@@ -6,7 +6,7 @@ namespace fl
 		Buffer(elementSize * vertexCount, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT),
 		m_vertexCount(static_cast<uint32_t>(vertexCount))
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		// Copies the vertex data to the buffer.
 		void *data;

--- a/Sources/Renderer/Descriptors/DescriptorSet.cpp
+++ b/Sources/Renderer/Descriptors/DescriptorSet.cpp
@@ -11,7 +11,7 @@ namespace fl
 		m_descriptorPool(pipeline.GetVkDescriptorPool()),
 		m_descriptorSet(VK_NULL_HANDLE)
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		VkDescriptorSetLayout layouts[1] = {pipeline.GetVkDescriptorSetLayout()};
 
@@ -28,7 +28,7 @@ namespace fl
 
 	DescriptorSet::~DescriptorSet()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		VkDescriptorSet descriptors[1] = {m_descriptorSet};
 		vkFreeDescriptorSets(logicalDevice, m_descriptorPool, 1, descriptors);
@@ -36,7 +36,7 @@ namespace fl
 
 	void DescriptorSet::Update(const std::vector<IDescriptor *> &descriptors)
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		std::vector<VkWriteDescriptorSet> descriptorWrites = {};
 
@@ -44,7 +44,7 @@ namespace fl
 		{
 			if (descriptors.at(i) != nullptr)
 			{
-				descriptorWrites.push_back(descriptors.at(i)->GetVkWriteDescriptor(i, *this));
+				descriptorWrites.emplace_back(descriptors.at(i)->GetVkWriteDescriptor(i, *this));
 			}
 		}
 

--- a/Sources/Renderer/Handlers/DescriptorsHandler.hpp
+++ b/Sources/Renderer/Handlers/DescriptorsHandler.hpp
@@ -35,6 +35,8 @@ namespace fl
 
 		bool Update(const Pipeline &pipeline);
 
+		void BindDescriptor(const CommandBuffer &commandBuffer) { m_descriptorSet->BindDescriptor(commandBuffer); }
+
 		DescriptorSet *GetDescriptorSet() const { return m_descriptorSet; }
 	};
 }

--- a/Sources/Renderer/Handlers/DescriptorsHandler.hpp
+++ b/Sources/Renderer/Handlers/DescriptorsHandler.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include "Renderer/Descriptors/DescriptorSet.hpp"
 #include "UniformHandler.hpp"
 
@@ -22,7 +23,11 @@ namespace fl
 
 		void Push(const std::string &descriptorName, IDescriptor *descriptor);
 
+		void Push(const std::string &descriptorName, std::shared_ptr<IDescriptor> descriptor) { Push(descriptorName, descriptor.get()); }
+
 		void Push(const std::string &descriptorName, UniformHandler *uniformHandler);
+
+		void Push(const std::string &descriptorName, std::shared_ptr<UniformHandler> uniformHandler) { Push(descriptorName, uniformHandler.get()); }
 
 		bool Update(const Pipeline &pipeline);
 

--- a/Sources/Renderer/Handlers/DescriptorsHandler.hpp
+++ b/Sources/Renderer/Handlers/DescriptorsHandler.hpp
@@ -23,9 +23,13 @@ namespace fl
 
 		void Push(const std::string &descriptorName, IDescriptor *descriptor);
 
+		void Push(const std::string &descriptorName, IDescriptor &descriptor) { Push(descriptorName, &descriptor); }
+
 		void Push(const std::string &descriptorName, std::shared_ptr<IDescriptor> descriptor) { Push(descriptorName, descriptor.get()); }
 
 		void Push(const std::string &descriptorName, UniformHandler *uniformHandler);
+
+		void Push(const std::string &descriptorName, UniformHandler &uniformHandler) { Push(descriptorName, &uniformHandler); }
 
 		void Push(const std::string &descriptorName, std::shared_ptr<UniformHandler> uniformHandler) { Push(descriptorName, uniformHandler.get()); }
 

--- a/Sources/Renderer/Handlers/UniformHandler.hpp
+++ b/Sources/Renderer/Handlers/UniformHandler.hpp
@@ -42,7 +42,6 @@ namespace fl
 				return;
 			}
 
-			//	printf("name: %s, offset %i, size: %i\n", uniformName.c_str(), uniform->m_offset, (int) sizeof(object));
 			Push(object, static_cast<size_t>(uniform->GetOffset()), size == 0 ? sizeof(object) : size); // static_cast<size_t>(uniform->m_size)
 		}
 

--- a/Sources/Renderer/Pipelines/Pipeline.cpp
+++ b/Sources/Renderer/Pipelines/Pipeline.cpp
@@ -96,8 +96,7 @@ namespace fl
 	{
 		return Renderer::Get()->GetRenderStage(stage == -1 ? m_graphicsStage.GetRenderpass() : stage)->GetFramebuffers()->GetTexture(i);
 	}
-
-
+	
 	EShLanguage GetEshLanguage(const VkShaderStageFlagBits &stageFlag)
 	{
 		switch (stageFlag)

--- a/Sources/Renderer/Pipelines/Pipeline.cpp
+++ b/Sources/Renderer/Pipelines/Pipeline.cpp
@@ -31,7 +31,7 @@ namespace fl
 		m_dynamicState({})
 	{
 #if FL_VERBOSE
-		const auto debugStart = Engine::Get()->GetTimeMs();
+		float debugStart = Engine::Get()->GetTimeMs();
 #endif
 
 		CreateShaderProgram();
@@ -60,7 +60,7 @@ namespace fl
 		}
 
 #if FL_VERBOSE
-		const auto debugEnd = Engine::Get()->GetTimeMs();
+		float debugEnd = Engine::Get()->GetTimeMs();
 	//	printf("%s", m_shaderProgram->ToString().c_str());
 		printf("Pipeline '%s' created in %fms\n", m_pipelineCreate.GetShaderStages().back().c_str(), debugEnd - debugStart);
 #endif
@@ -68,7 +68,7 @@ namespace fl
 
 	Pipeline::~Pipeline()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		for (auto shaderModule : m_modules)
 		{
@@ -218,7 +218,7 @@ namespace fl
 
 	void Pipeline::CreateShaderProgram()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		std::string defineBlock = "\n";
 
@@ -301,8 +301,8 @@ namespace fl
 			pipelineShaderStageCreateInfo.module = shaderModule;
 			pipelineShaderStageCreateInfo.pName = "main";
 
-			m_modules.push_back(shaderModule);
-			m_stages.push_back(pipelineShaderStageCreateInfo);
+			m_modules.emplace_back(shaderModule);
+			m_stages.emplace_back(pipelineShaderStageCreateInfo);
 		}
 
 		m_shaderProgram->ProcessShader();
@@ -310,13 +310,13 @@ namespace fl
 
 	void Pipeline::CreateDescriptorLayout()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		std::vector<VkDescriptorSetLayoutBinding> bindings = std::vector<VkDescriptorSetLayoutBinding>();
 
 		for (auto type : *m_shaderProgram->GetDescriptors())
 		{
-			bindings.push_back(type.GetLayoutBinding());
+			bindings.emplace_back(type.GetLayoutBinding());
 		}
 
 		VkDescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo = {};
@@ -330,13 +330,13 @@ namespace fl
 
 	void Pipeline::CreateDescriptorPool()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		std::vector<VkDescriptorPoolSize> poolSizes = std::vector<VkDescriptorPoolSize>();
 
 		for (auto type : *m_shaderProgram->GetDescriptors())
 		{
-			poolSizes.push_back(type.GetPoolSize());
+			poolSizes.emplace_back(type.GetPoolSize());
 		}
 
 		VkDescriptorPoolCreateInfo descriptorPoolCreateInfo = {};
@@ -352,7 +352,7 @@ namespace fl
 
 	void Pipeline::CreatePipelineLayout()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = {};
 		pipelineLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
@@ -436,9 +436,9 @@ namespace fl
 
 	void Pipeline::CreatePipelinePolygon()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
-		const auto pipelineCache = Renderer::Get()->GetVkPipelineCache();
-		const auto renderStage = Renderer::Get()->GetRenderStage(m_graphicsStage.GetRenderpass());
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto pipelineCache = Renderer::Get()->GetVkPipelineCache();
+		auto renderStage = Renderer::Get()->GetRenderStage(m_graphicsStage.GetRenderpass());
 
 		VkPipelineVertexInputStateCreateInfo vertexInputStateCreateInfo = {};
 		vertexInputStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
@@ -497,7 +497,7 @@ namespace fl
 			blendAttachmentState.alphaBlendOp = VK_BLEND_OP_ADD;
 			blendAttachmentState.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
 				VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-			blendAttachmentStates.push_back(blendAttachmentState);
+			blendAttachmentStates.emplace_back(blendAttachmentState);
 		}
 
 		m_colourBlendState.attachmentCount = static_cast<uint32_t>(blendAttachmentStates.size());
@@ -522,7 +522,7 @@ namespace fl
 			blendAttachmentState.alphaBlendOp = VK_BLEND_OP_ADD;
 			blendAttachmentState.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
 				VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-			blendAttachmentStates.push_back(blendAttachmentState);
+			blendAttachmentStates.emplace_back(blendAttachmentState);
 		}
 
 		m_colourBlendState.attachmentCount = static_cast<uint32_t>(blendAttachmentStates.size());

--- a/Sources/Renderer/Pipelines/ShaderProgram.cpp
+++ b/Sources/Renderer/Pipelines/ShaderProgram.cpp
@@ -71,7 +71,7 @@ namespace fl
 		{
 			if (reportIfFound)
 			{
-				m_notFoundNames.push_back(name);
+				m_notFoundNames.emplace_back(name);
 			}
 
 			return true;
@@ -116,7 +116,7 @@ namespace fl
 		// Process to descriptors.
 		for (auto uniformBlock : *m_uniformBlocks)
 		{
-			m_descriptors->push_back(UniformBuffer::CreateDescriptor(static_cast<uint32_t>(uniformBlock->GetBinding()), uniformBlock->GetStageFlags()));
+			m_descriptors->emplace_back(UniformBuffer::CreateDescriptor(static_cast<uint32_t>(uniformBlock->GetBinding()), uniformBlock->GetStageFlags()));
 		}
 
 		for (auto uniform : *m_uniforms)
@@ -125,11 +125,11 @@ namespace fl
 			{
 			case 0x8B5E:
 			case 0x904D:
-				m_descriptors->push_back(Texture::CreateDescriptor(static_cast<uint32_t>(uniform->GetBinding()), uniform->GetStageFlags()));
+				m_descriptors->emplace_back(Texture::CreateDescriptor(static_cast<uint32_t>(uniform->GetBinding()), uniform->GetStageFlags()));
 				break;
 			case 0x8B60:
 			case 0x904E:
-				m_descriptors->push_back(Cubemap::CreateDescriptor(static_cast<uint32_t>(uniform->GetBinding()), uniform->GetStageFlags()));
+				m_descriptors->emplace_back(Cubemap::CreateDescriptor(static_cast<uint32_t>(uniform->GetBinding()), uniform->GetStageFlags()));
 				break;
 			default:
 				break;
@@ -147,7 +147,7 @@ namespace fl
 			attributeDescription.format = GlTypeToVk(vertexAttribute->GetGlType());
 			attributeDescription.offset = currentOffset;
 
-			m_attributeDescriptions->push_back(attributeDescription);
+			m_attributeDescriptions->emplace_back(attributeDescription);
 			currentOffset += vertexAttribute->GetSize();
 		}
 	}
@@ -323,7 +323,7 @@ namespace fl
 			}
 		}
 
-		m_uniformBlocks->push_back(new UniformBlock(program.getUniformBlockName(i), program.getUniformBlockBinding(i), program.getUniformBlockSize(i), stageFlag));
+		m_uniformBlocks->emplace_back(new UniformBlock(program.getUniformBlockName(i), program.getUniformBlockBinding(i), program.getUniformBlockSize(i), stageFlag));
 	}
 
 	void ShaderProgram::LoadUniform(const glslang::TProgram &program, const VkShaderStageFlagBits &stageFlag, const int &i)
@@ -355,7 +355,7 @@ namespace fl
 			}
 		}
 
-		m_uniforms->push_back(new Uniform(program.getUniformName(i), program.getUniformBinding(i), program.getUniformBufferOffset(i), -1, program.getUniformType(i), stageFlag));
+		m_uniforms->emplace_back(new Uniform(program.getUniformName(i), program.getUniformBinding(i), program.getUniformBufferOffset(i), -1, program.getUniformType(i), stageFlag));
 	}
 
 	void ShaderProgram::LoadVertexAttribute(const glslang::TProgram &program, const VkShaderStageFlagBits &stageFlag, const int &i)
@@ -368,7 +368,7 @@ namespace fl
 			}
 		}
 
-		m_vertexAttributes->push_back(new VertexAttribute(program.getAttributeName(i), program.getAttributeTType(i)->getQualifier().layoutLocation,
+		m_vertexAttributes->emplace_back(new VertexAttribute(program.getAttributeName(i), program.getAttributeTType(i)->getQualifier().layoutLocation,
 			sizeof(float) * program.getAttributeTType(i)->getVectorSize(), program.getAttributeType(i)));
 	}
 }

--- a/Sources/Renderer/Pipelines/ShaderProgram.hpp
+++ b/Sources/Renderer/Pipelines/ShaderProgram.hpp
@@ -103,7 +103,7 @@ namespace fl
 				}
 			}
 
-			m_uniforms->push_back(uniform);
+			m_uniforms->emplace_back(uniform);
 		}
 
 		Uniform *GetUniform(const std::string &uniformName)

--- a/Sources/Renderer/Queue/QueueFamily.cpp
+++ b/Sources/Renderer/Queue/QueueFamily.cpp
@@ -4,7 +4,7 @@ namespace fl
 {
 	QueueFamilyIndices QueueFamily::FindQueueFamilies(const VkSurfaceKHR &surface)
 	{
-		const auto physicalDevice = Display::Get()->GetVkPhysicalDevice();
+		auto physicalDevice = Display::Get()->GetVkPhysicalDevice();
 
 		int graphicsFamily = -1;
 		int presentFamily = -1;

--- a/Sources/Renderer/RenderStage.cpp
+++ b/Sources/Renderer/RenderStage.cpp
@@ -36,7 +36,7 @@ namespace fl
 				break;
 			}
 
-			m_clearValues.push_back(clearValue);
+			m_clearValues.emplace_back(clearValue);
 		}
 	}
 
@@ -51,10 +51,10 @@ namespace fl
 	void RenderStage::Rebuild(Swapchain *swapchain)
 	{
 #if FL_VERBOSE
-		const auto debugStart = Engine::Get()->GetTimeMs();
+		float debugStart = Engine::Get()->GetTimeMs();
 #endif
 
-		const auto surfaceFormat = Display::Get()->GetVkSurfaceFormat();
+		auto surfaceFormat = Display::Get()->GetVkSurfaceFormat();
 		const VkExtent2D extent2D = {GetWidth(), GetHeight()};
 		const VkExtent3D extent3D = {GetWidth(), GetHeight(), 1};
 
@@ -73,7 +73,7 @@ namespace fl
 		m_framebuffers = new Framebuffers(*m_renderpassCreate, *m_renderpass, *swapchain, *m_depthStencil, extent2D);
 
 #if FL_VERBOSE
-		const auto debugEnd = Engine::Get()->GetTimeMs();
+		float debugEnd = Engine::Get()->GetTimeMs();
 		printf("Renderstage '%i' built in %fms\n", m_stageIndex, debugEnd - debugStart);
 #endif
 	}

--- a/Sources/Renderer/Renderer.cpp
+++ b/Sources/Renderer/Renderer.cpp
@@ -21,8 +21,8 @@ namespace fl
 
 	Renderer::~Renderer()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
-		const auto queue = Display::Get()->GetVkQueue();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto queue = Display::Get()->GetVkQueue();
 
 		vkQueueWaitIdle(queue);
 
@@ -56,7 +56,7 @@ namespace fl
 	void Renderer::CreateRenderpass(std::vector<RenderpassCreate *> renderpassCreates)
 	{
 #if FL_VERBOSE
-		const auto debugStart = Engine::Get()->GetTimeMs();
+		float debugStart = Engine::Get()->GetTimeMs();
 #endif
 
 		const VkExtent2D displayExtent2D = {
@@ -70,21 +70,21 @@ namespace fl
 		{
 			auto renderStage = new RenderStage(m_renderStages.size(), renderpassCreate);
 			renderStage->Rebuild(m_swapchain);
-			m_renderStages.push_back(renderStage);
+			m_renderStages.emplace_back(renderStage);
 		}
 
 		vkDeviceWaitIdle(Display::Get()->GetVkLogicalDevice());
 		vkQueueWaitIdle(Display::Get()->GetVkQueue());
 
 #if FL_VERBOSE
-		const auto debugEnd = Engine::Get()->GetTimeMs();
+		float debugEnd = Engine::Get()->GetTimeMs();
 		printf("Renderpass created in %fms\n", debugEnd - debugStart);
 #endif
 	}
 
 	bool Renderer::StartRenderpass(const CommandBuffer &commandBuffer, const unsigned int &i)
 	{
-		const auto renderStage = GetRenderStage(i);
+		auto renderStage = GetRenderStage(i);
 
 		if (renderStage->IsOutOfDate(m_swapchain->GetVkExtent()))
 		{
@@ -92,8 +92,8 @@ namespace fl
 			return false; // VK_ERROR_INITIALIZATION_FAILED
 		}
 
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
-		const auto queue = Display::Get()->GetVkQueue();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto queue = Display::Get()->GetVkQueue();
 
 		Display::ErrorVk(vkQueueWaitIdle(queue));
 
@@ -160,8 +160,8 @@ namespace fl
 
 	void Renderer::EndRenderpass(const CommandBuffer &commandBuffer, const unsigned int &i)
 	{
-		const auto renderStage = GetRenderStage(i);
-		const auto queue = Display::Get()->GetVkQueue();
+		auto renderStage = GetRenderStage(i);
+		auto queue = Display::Get()->GetVkQueue();
 
 		vkCmdEndRenderPass(commandBuffer.GetVkCommandBuffer());
 		Display::ErrorVk(vkEndCommandBuffer(commandBuffer.GetVkCommandBuffer()));
@@ -245,7 +245,7 @@ namespace fl
 
 	void Renderer::CreateFences()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		VkFenceCreateInfo fenceCreateInfo = {};
 		fenceCreateInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
@@ -254,7 +254,7 @@ namespace fl
 
 	void Renderer::CreateCommandPool()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		VkSemaphoreCreateInfo semaphoreCreateInfo = {};
 		semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
@@ -273,7 +273,7 @@ namespace fl
 
 	void Renderer::CreatePipelineCache()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		VkPipelineCacheCreateInfo pipelineCacheCreateInfo = {};
 		pipelineCacheCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
@@ -283,8 +283,8 @@ namespace fl
 
 	void Renderer::RecreatePass(const int &i)
 	{
-		const auto queue = Display::Get()->GetVkQueue();
-		const auto renderStage = GetRenderStage(i);
+		auto queue = Display::Get()->GetVkQueue();
+		auto renderStage = GetRenderStage(i);
 
 		const VkExtent2D displayExtent2D = {
 			static_cast<uint32_t>(Display::Get()->GetWidth()), static_cast<uint32_t>(Display::Get()->GetHeight())

--- a/Sources/Renderer/Renderpass/Renderpass.cpp
+++ b/Sources/Renderer/Renderpass/Renderpass.cpp
@@ -7,7 +7,7 @@ namespace fl
 	Renderpass::Renderpass(const RenderpassCreate &renderpassCreate, const DepthStencil &depthStencil, const VkFormat &surfaceFormat) :
 		m_renderPass(VK_NULL_HANDLE)
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		// Attachments,
 		std::vector<VkAttachmentDescription> attachments = {};
@@ -38,7 +38,7 @@ namespace fl
 				break;
 			}
 
-			attachments.push_back(attachment);
+			attachments.emplace_back(attachment);
 		}
 
 		// Subpasses and dependencies.
@@ -62,7 +62,7 @@ namespace fl
 				VkAttachmentReference attachmentReference = {};
 				attachmentReference.attachment = attachment;
 				attachmentReference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-				subpassColourAttachments->push_back(attachmentReference);
+				subpassColourAttachments->emplace_back(attachmentReference);
 			}
 
 			// Description.
@@ -79,7 +79,7 @@ namespace fl
 				subpassDescription.pDepthStencilAttachment = &subpassDepthStencilAttachment;
 			}
 
-			subpasses.push_back(subpassDescription);
+			subpasses.emplace_back(subpassDescription);
 
 			// Dependencies.
 			VkSubpassDependency subpassDependency = {};
@@ -113,7 +113,7 @@ namespace fl
 				subpassDependency.dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 			}
 
-			dependencies.push_back(subpassDependency);
+			dependencies.emplace_back(subpassDependency);
 		}
 
 		// Creates the render pass.
@@ -131,7 +131,7 @@ namespace fl
 
 	Renderpass::~Renderpass()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		vkDestroyRenderPass(logicalDevice, m_renderPass, nullptr);
 	}

--- a/Sources/Renderer/Screenshot/Screenshot.cpp
+++ b/Sources/Renderer/Screenshot/Screenshot.cpp
@@ -10,15 +10,15 @@ namespace fl
 	void Screenshot::Capture(const std::string &filename)
 	{
 #if FL_VERBOSE
-		const auto debugStart = Engine::Get()->GetTimeMs();
+		float debugStart = Engine::Get()->GetTimeMs();
 #endif
 
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
-		const auto physicalDevice = Display::Get()->GetVkPhysicalDevice();
-		const auto surfaceFormat = Display::Get()->GetVkSurfaceFormat();
-		const auto physicalDeviceMemoryProperties = Display::Get()->GetVkPhysicalDeviceMemoryProperties();
-		const auto width = Display::Get()->GetWidth();
-		const auto height = Display::Get()->GetHeight();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto physicalDevice = Display::Get()->GetVkPhysicalDevice();
+		auto surfaceFormat = Display::Get()->GetVkSurfaceFormat();
+		auto physicalDeviceMemoryProperties = Display::Get()->GetVkPhysicalDeviceMemoryProperties();
+		auto width = Display::Get()->GetWidth();
+		auto height = Display::Get()->GetHeight();
 		VkImage srcImage = Renderer::Get()->GetSwapchain()->GetVkImages().at(Renderer::Get()->GetVkActiveSwapchainImage());
 
 		printf("Saving screenshot to: '%s'\n", filename.c_str());
@@ -188,7 +188,7 @@ namespace fl
 		delete[] data;
 
 #if FL_VERBOSE
-		const auto debugEnd = Engine::Get()->GetTimeMs();
+		float debugEnd = Engine::Get()->GetTimeMs();
 		printf("Screenshot '%s' saved in %fms\n", filename.c_str(), debugEnd - debugStart);
 #endif
 	}

--- a/Sources/Renderer/Swapchain/DepthStencil.cpp
+++ b/Sources/Renderer/Swapchain/DepthStencil.cpp
@@ -22,8 +22,8 @@ namespace fl
 		m_format(VK_FORMAT_UNDEFINED),
 		m_imageInfo({})
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
-		const auto physicalDevice = Display::Get()->GetVkPhysicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto physicalDevice = Display::Get()->GetVkPhysicalDevice();
 
 		for (auto format : TRY_FORMATS)
 		{
@@ -125,7 +125,7 @@ namespace fl
 
 	DepthStencil::~DepthStencil()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		vkDestroySampler(logicalDevice, m_sampler, nullptr);
 		vkDestroyImageView(logicalDevice, m_imageView, nullptr);

--- a/Sources/Renderer/Swapchain/Framebuffers.cpp
+++ b/Sources/Renderer/Swapchain/Framebuffers.cpp
@@ -9,7 +9,7 @@ namespace fl
 		m_imageAttachments(std::vector<Texture *>()),
 		m_framebuffers(std::vector<VkFramebuffer>())
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		uint32_t width = renderpassCreate.GetWidth() == 0 ? Display::Get()->GetWidth() : renderpassCreate.GetWidth();
 		uint32_t height = renderpassCreate.GetHeight() == 0 ? Display::Get()->GetHeight() : renderpassCreate.GetHeight();
@@ -19,13 +19,13 @@ namespace fl
 			switch (image.GetType())
 			{
 			case ATTACHMENT_IMAGE:
-				m_imageAttachments.push_back(new Texture(width, height, static_cast<VkFormat>(image.GetFormat()), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT));
+				m_imageAttachments.emplace_back(new Texture(width, height, static_cast<VkFormat>(image.GetFormat()), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT));
 				break;
 			case ATTACHMENT_DEPTH:
-				m_imageAttachments.push_back(nullptr);
+				m_imageAttachments.emplace_back(nullptr);
 				break;
 			case ATTACHMENT_SWAPCHAIN:
-				m_imageAttachments.push_back(nullptr);
+				m_imageAttachments.emplace_back(nullptr);
 				break;
 			}
 		}
@@ -41,13 +41,13 @@ namespace fl
 				switch (image.GetType())
 				{
 				case ATTACHMENT_IMAGE:
-					attachments.push_back(GetTexture(image.GetBinding())->GetImageView());
+					attachments.emplace_back(GetTexture(image.GetBinding())->GetImageView());
 					break;
 				case ATTACHMENT_DEPTH:
-					attachments.push_back(depthStencil.GetVkImageView());
+					attachments.emplace_back(depthStencil.GetVkImageView());
 					break;
 				case ATTACHMENT_SWAPCHAIN:
-					attachments.push_back(swapchain.GetVkImageViews().at(i));
+					attachments.emplace_back(swapchain.GetVkImageViews().at(i));
 					break;
 				}
 			}
@@ -67,7 +67,7 @@ namespace fl
 
 	Framebuffers::~Framebuffers()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		for (auto attachment : m_imageAttachments)
 		{

--- a/Sources/Renderer/Swapchain/Swapchain.cpp
+++ b/Sources/Renderer/Swapchain/Swapchain.cpp
@@ -12,12 +12,12 @@ namespace fl
 		m_swapchainImageViews(std::vector<VkImageView>()),
 		m_extent({})
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
-		const auto physicalDevice = Display::Get()->GetVkPhysicalDevice();
-		const auto surface = Display::Get()->GetVkSurface();
-		const auto surfaceFormat = Display::Get()->GetVkSurfaceFormat();
-		const auto surfaceCapabilities = Display::Get()->GetVkSurfaceCapabilities();
-		const auto indices = QueueFamily::FindQueueFamilies(surface);
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto physicalDevice = Display::Get()->GetVkPhysicalDevice();
+		auto surface = Display::Get()->GetVkSurface();
+		auto surfaceFormat = Display::Get()->GetVkSurfaceFormat();
+		auto surfaceCapabilities = Display::Get()->GetVkSurfaceCapabilities();
+		auto indices = QueueFamily::FindQueueFamilies(surface);
 
 		m_extent = extent;
 
@@ -104,7 +104,7 @@ namespace fl
 
 	Swapchain::~Swapchain()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		for (auto imageView : m_swapchainImageViews)
 		{

--- a/Sources/Resources/Resources.cpp
+++ b/Sources/Resources/Resources.cpp
@@ -3,47 +3,57 @@
 namespace fl
 {
 	Resources::Resources() :
-		m_managed(new std::vector<IResource *>())
+		m_resources(std::vector<std::shared_ptr<IResource>>())
 	{
 	}
 
 	Resources::~Resources()
 	{
-		for (auto managed : *m_managed)
-		{
-			delete managed;
-		}
-
-		delete m_managed;
 	}
 
 	void Resources::Update()
 	{
 	}
 
-	IResource *Resources::Get(const std::string &filename)
+	std::shared_ptr<IResource> Resources::Get(const std::string &filename)
 	{
-		for (auto managed : *m_managed)
+		for (auto resource : m_resources)
 		{
-			if (managed != nullptr && managed->GetFilename() == filename)
+			if (resource != nullptr && resource->GetFilename() == filename)
 			{
-				return managed;
+				return resource;
 			}
 		}
 
 		return nullptr;
 	}
 
-	void Resources::Add(IResource *managed)
+	void Resources::Add(std::shared_ptr<IResource> resource)
 	{
-		m_managed->push_back(managed);
+		m_resources.emplace_back(resource);
 	}
 
-	void Resources::Remove(IResource *managed)
+	void Resources::Remove(std::shared_ptr<IResource> resource)
 	{
+		for (auto it = m_resources.begin(); it != m_resources.end(); ++it)
+		{
+			if (*it == resource)
+			{
+			//	delete (*it);
+				m_resources.erase(it);
+			}
+		}
 	}
 
 	void Resources::Remove(const std::string &filename)
 	{
+		for (auto it = m_resources.begin(); it != m_resources.end(); ++it)
+		{
+			if ((*it)->GetFilename() == filename)
+			{
+			//	delete *it;
+				m_resources.erase(it);
+			}
+		}
 	}
 }

--- a/Sources/Resources/Resources.hpp
+++ b/Sources/Resources/Resources.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <memory>
 #include "Engine/Engine.hpp"
 #include "IResource.hpp"
 
@@ -13,7 +14,7 @@ namespace fl
 		public IModule
 	{
 	private:
-		std::vector<IResource *> *m_managed;
+		std::vector<std::shared_ptr<IResource>> m_resources;
 	public:
 		/// <summary>
 		/// Gets this engine instance.
@@ -36,11 +37,11 @@ namespace fl
 
 		void Update() override;
 
-		IResource *Get(const std::string &filename);
+		std::shared_ptr<IResource> Get(const std::string &filename);
 
-		void Add(IResource *managed);
+		void Add(std::shared_ptr<IResource> resource);
 
-		void Remove(IResource *managed);
+		void Remove(std::shared_ptr<IResource> resource);
 
 		void Remove(const std::string &filename);
 	};

--- a/Sources/Scenes/ICamera.hpp
+++ b/Sources/Scenes/ICamera.hpp
@@ -61,42 +61,42 @@ namespace fl
 		/// Gets the view frustum created by the current camera position and rotation.
 		/// </summary>
 		/// <returns> The view frustum created by the current camera position and rotation. </returns>
-		virtual Frustum *GetViewFrustum() const = 0;
+		virtual Frustum GetViewFrustum() const = 0;
 
 		/// <summary>
 		/// Gets the ray that extends from the cameras position though the screen.
 		/// </summary>
 		/// <returns> The cameras view ray. </returns>
-		virtual Ray *GetViewRay() const = 0;
+		virtual Ray GetViewRay() const = 0;
 
 		/// <summary>
 		/// Gets the view matrix created by the current camera position and rotation.
 		/// </summary>
 		/// <returns> The view matrix created by the current camera position and rotation. </returns>
-		virtual Matrix4 *GetViewMatrix() const = 0;
+		virtual Matrix4 GetViewMatrix() const = 0;
 
 		/// <summary>
 		/// Gets the projection matrix used in the current scene render.
 		/// </summary>
 		/// <returns> The projection matrix used in the current scene render. </returns>
-		virtual Matrix4 *GetProjectionMatrix() const = 0;
+		virtual Matrix4 GetProjectionMatrix() const = 0;
 
 		/// <summary>
 		/// Gets the cameras 3D position in the world.
 		/// </summary>
 		/// <returns> The cameras 3D position in the world. </returns>
-		virtual Vector3 *GetPosition() const = 0;
+		virtual Vector3 GetPosition() const = 0;
 
 		/// <summary>
 		/// Gets the cameras 3D velocity in the world.
 		/// </summary>
 		/// <returns> The cameras 3D velocity in the world. </returns>
-		virtual Vector3 *GetVelocity() const = 0;
+		virtual Vector3 GetVelocity() const = 0;
 
 		/// <summary>
 		/// Gets the cameras 3D rotation in the world, where x=pitch, y=yaw, z=roll.
 		/// </summary>
 		/// <returns> The cameras 3D rotation in the world, where x=pitch, y=yaw, z=roll. </returns>
-		virtual Vector3 *GetRotation() const = 0;
+		virtual Vector3 GetRotation() const = 0;
 	};
 }

--- a/Sources/Scenes/ICamera.hpp
+++ b/Sources/Scenes/ICamera.hpp
@@ -36,8 +36,8 @@ namespace fl
 		/// <summary>
 		/// Prepares the camera for the reflection render pass.
 		/// </summary>
-		/// <param name="waterHeight"> The height of the water to be reflected on. </param>
-		virtual void ReflectView(const float &waterHeight) = 0;
+		/// <param name="height"> The height of the horizontal plane to be reflected over. </param>
+		virtual void ReflectView(const float &height) = 0;
 
 		/// <summary>
 		/// Gets the distance of the near pane of the view frustum.

--- a/Sources/Scenes/IManagerUis.hpp
+++ b/Sources/Scenes/IManagerUis.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Maths/Colour.hpp"
+#include "Uis/UiSelector.hpp"
 
 namespace fl
 {
@@ -45,6 +46,12 @@ namespace fl
 		/// The primary colour to be used in UI elements.
 		/// </summary>
 		/// <returns> The primary colour. </returns>
-		virtual Colour *GetPrimaryColour() = 0;
+		virtual Colour *GetPrimaryColour() const = 0;
+
+		/// <summary>
+		/// The UI selector for a joystick.
+		/// </summary>
+		/// <returns> The joystick selector. </returns>
+		virtual SelectorJoystick *GetSelectorJoystick() const = 0;
 	};
 }

--- a/Sources/Scenes/ISpatialStructure.hpp
+++ b/Sources/Scenes/ISpatialStructure.hpp
@@ -59,24 +59,22 @@ namespace fl
 		/// </summary>
 		/// </param>
 		/// <returns> The list specified by of all objects. </returns>
-		virtual std::vector<GameObject *> *GetAll() = 0;
+		virtual std::vector<GameObject *> GetAll() = 0;
 
 		/// <summary>
 		/// Returns a set of all objects in the spatial structure.
 		/// </summary>
-		/// <param name="result"> The list to store the data into.
 		/// </param>
 		/// <returns> The list specified by of all objects. </returns>
-		virtual std::vector<GameObject *> *QueryAll(std::vector<GameObject *> *result) = 0;
+		virtual std::vector<GameObject *> QueryAll() = 0;
 
 		/// <summary>
 		/// Returns a set of all objects in a specific range of the spatial structure.
 		/// </summary>
 		/// <param name="range"> The frustum range of space being queried. </param>
-		/// <param name="result"> The list to store the data into.
 		/// </param>
 		/// <returns> The list of all object in range. </returns>
-		virtual std::vector<GameObject *> *QueryFrustum(Frustum *range, std::vector<GameObject *> *result) = 0;
+		virtual std::vector<GameObject *> QueryFrustum(const Frustum &range) = 0;
 
 		/// <summary>
 		/// Returns a set of all objects in a specific range of the spatial structure.
@@ -85,7 +83,7 @@ namespace fl
 		/// <param name="result"> The list to store the data into.
 		/// </param>
 		/// <returns> The list of all object in range. </returns>
-		virtual std::vector<GameObject *> *QueryBounding(ICollider *range, std::vector<GameObject *> *result) = 0;
+		virtual std::vector<GameObject *> QueryBounding(ICollider *range) = 0;
 
 		/// <summary>
 		/// If the structure contains the object.

--- a/Sources/Scenes/ISpatialStructure.hpp
+++ b/Sources/Scenes/ISpatialStructure.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <memory>
 #include "Physics/Frustum.hpp"
 
 namespace fl

--- a/Sources/Scenes/SceneStructure.cpp
+++ b/Sources/Scenes/SceneStructure.cpp
@@ -10,10 +10,6 @@ namespace fl
 
 	SceneStructure::~SceneStructure()
 	{
-		for (auto object : m_objects)
-		{
-			delete object;
-		}
 	}
 
 	void SceneStructure::Add(GameObject *object)

--- a/Sources/Scenes/SceneStructure.cpp
+++ b/Sources/Scenes/SceneStructure.cpp
@@ -4,78 +4,80 @@ namespace fl
 {
 	SceneStructure::SceneStructure() :
 		ISpatialStructure(),
-		m_objects(new std::vector<GameObject *>())
+		m_objects(std::vector<GameObject *>())
 	{
 	}
 
 	SceneStructure::~SceneStructure()
 	{
-		for (auto it = m_objects->begin(); it != m_objects->end(); ++it)
+		for (auto object : m_objects)
 		{
-			delete *it;
+			delete object;
 		}
-
-		delete m_objects;
 	}
 
 	void SceneStructure::Add(GameObject *object)
 	{
-		m_objects->push_back(object);
+		m_objects.emplace_back(object);
 	}
 
 	void SceneStructure::Remove(GameObject *object)
 	{
-		for (auto it = m_objects->begin(); it != m_objects->end(); ++it)
+		auto found = std::find(m_objects.begin(), m_objects.end(), object);
+
+		if (found != m_objects.end())
 		{
-			if (*it == object)
-			{
-				m_objects->erase(it);
-				return;
-			}
+			m_objects.erase(found);
 		}
 	}
 
 	void SceneStructure::Clear()
 	{
-		m_objects->clear();
+		m_objects.clear();
 	}
 
-	std::vector<GameObject *> *SceneStructure::QueryAll(std::vector<GameObject *> *result)
+	std::vector<GameObject *> SceneStructure::QueryAll()
 	{
-		for (auto it = m_objects->begin(); it != m_objects->end(); ++it)
+		auto result = std::vector<GameObject *>();
+
+		for (auto it = m_objects.begin(); it != m_objects.end(); ++it)
 		{
-			result->push_back(*it);
+			result.emplace_back(*it);
 		}
 
 		return result;
 	}
 
-	std::vector<GameObject *> *SceneStructure::QueryFrustum(Frustum *range, std::vector<GameObject *> *result)
+	std::vector<GameObject *> SceneStructure::QueryFrustum(const Frustum &range)
 	{
-		for (auto it = m_objects->begin(); it != m_objects->end(); ++it)
+		auto result = std::vector<GameObject *>();
+
+		for (auto it = m_objects.begin(); it != m_objects.end(); ++it)
 		{
 			auto gameObject = static_cast<GameObject *>(*it);
 			auto rigidbody = gameObject->GetComponent<Rigidbody>();
 
-			if (rigidbody == nullptr || rigidbody->GetCollider()->InFrustum(*range))
+			if (rigidbody == nullptr || rigidbody->GetCollider()->InFrustum(range))
 			{
-				result->push_back(*it);
+				result.emplace_back(*it);
 			}
 		}
 
 		return result;
 	}
 
-	std::vector<GameObject *> *SceneStructure::QueryBounding(ICollider *range, std::vector<GameObject *> *result)
+	std::vector<GameObject *> SceneStructure::QueryBounding(ICollider *range)
 	{
-		for (auto it = m_objects->begin(); it != m_objects->end(); ++it)
+		auto result = std::vector<GameObject *>();
+
+		for (auto it = m_objects.begin(); it != m_objects.end(); ++it)
 		{
 			auto gameObject = static_cast<GameObject *>(*it);
 			auto rigidbody = gameObject->GetComponent<Rigidbody>();
 
 			if (rigidbody == nullptr || range->Intersects(*rigidbody->GetCollider()).IsIntersection() || range->Contains(*rigidbody->GetCollider()))
 			{
-				result->push_back(*it);
+				result.emplace_back(*it);
 			}
 		}
 
@@ -84,6 +86,6 @@ namespace fl
 
 	bool SceneStructure::Contains(GameObject *object)
 	{
-		return std::find(m_objects->begin(), m_objects->end(), object) != m_objects->end();
+		return std::find(m_objects.begin(), m_objects.end(), object) != m_objects.end();
 	}
 }

--- a/Sources/Scenes/SceneStructure.hpp
+++ b/Sources/Scenes/SceneStructure.hpp
@@ -43,14 +43,13 @@ namespace fl
 		/// </summary>
 		/// <returns> The list specified by of all components that match the type. </returns>
 		template<typename T>
-		std::vector<T *> QueryComponents()
+		std::vector<std::shared_ptr<T>> QueryComponents()
 		{
-			auto result = std::vector<T *>();
+			auto result = std::vector<std::shared_ptr<T>>();
 
 			for (auto it = m_objects.begin(); it != m_objects.end(); ++it)
 			{
-				auto gameObject = static_cast<GameObject *>(*it);
-				auto component = gameObject->GetComponent<T>();
+				auto component = (*it)->GetComponent<T>();
 
 				if (component != nullptr)
 				{
@@ -66,12 +65,11 @@ namespace fl
 		/// </summary>
 		/// <returns> The first component of the type found. </returns>
 		template<typename T>
-		T *GetComponent()
+		std::shared_ptr<T> GetComponent()
 		{
 			for (auto it = m_objects.begin(); it != m_objects.end(); ++it)
 			{
-				auto gameObject = static_cast<GameObject *>(*it);
-				auto component = gameObject->GetComponent<T>();
+				auto component = (*it)->GetComponent<T>();
 
 				if (component != nullptr)
 				{

--- a/Sources/Scenes/SceneStructure.hpp
+++ b/Sources/Scenes/SceneStructure.hpp
@@ -16,7 +16,7 @@ namespace fl
 		public ISpatialStructure
 	{
 	private:
-		std::vector<GameObject *> *m_objects;
+		std::vector<GameObject *> m_objects;
 	public:
 		/// <summary>
 		/// Creates a new basic structure.
@@ -34,26 +34,27 @@ namespace fl
 
 		void Clear() override;
 
-		unsigned int GetSize() override { return m_objects->size(); }
+		unsigned int GetSize() override { return m_objects.size(); }
 
-		std::vector<GameObject *> *GetAll() override { return m_objects; }
+		std::vector<GameObject *> GetAll() override { return m_objects; }
 
 		/// <summary>
 		/// Returns a set of all components of a type in the spatial structure.
 		/// </summary>
-		/// <param name="result"> The list to store the data into.</param>
 		/// <returns> The list specified by of all components that match the type. </returns>
 		template<typename T>
-		std::vector<T *> *QueryComponents(std::vector<T *> *result)
+		std::vector<T *> QueryComponents()
 		{
-			for (auto it = m_objects->begin(); it != m_objects->end(); ++it)
+			auto result = std::vector<T *>();
+
+			for (auto it = m_objects.begin(); it != m_objects.end(); ++it)
 			{
 				auto gameObject = static_cast<GameObject *>(*it);
 				auto component = gameObject->GetComponent<T>();
 
 				if (component != nullptr)
 				{
-					result->push_back(component);
+					result.emplace_back(component);
 				}
 			}
 
@@ -67,7 +68,7 @@ namespace fl
 		template<typename T>
 		T *GetComponent()
 		{
-			for (auto it = m_objects->begin(); it != m_objects->end(); ++it)
+			for (auto it = m_objects.begin(); it != m_objects.end(); ++it)
 			{
 				auto gameObject = static_cast<GameObject *>(*it);
 				auto component = gameObject->GetComponent<T>();
@@ -81,11 +82,11 @@ namespace fl
 			return nullptr;
 		}
 
-		std::vector<GameObject *> *QueryAll(std::vector<GameObject *> *result) override;
+		std::vector<GameObject *> QueryAll() override;
 
-		std::vector<GameObject *> *QueryFrustum(Frustum *range, std::vector<GameObject *> *result) override;
+		std::vector<GameObject *> QueryFrustum(const Frustum &range) override;
 
-		std::vector<GameObject *> *QueryBounding(ICollider *range, std::vector<GameObject *> *result) override;
+		std::vector<GameObject *> QueryBounding(ICollider *range) override;
 
 		bool Contains(GameObject *object) override;
 	};

--- a/Sources/Scenes/Scenes.cpp
+++ b/Sources/Scenes/Scenes.cpp
@@ -29,7 +29,7 @@ namespace fl
 			return;
 		}
 
-		std::vector<GameObject *> gameObjects = *m_scene->GetStructure()->GetAll();
+		auto gameObjects = m_scene->GetStructure()->GetAll();
 
 		for (auto it = gameObjects.begin(); it != gameObjects.end(); ++it)
 		{

--- a/Sources/Scenes/Scenes.hpp
+++ b/Sources/Scenes/Scenes.hpp
@@ -58,7 +58,7 @@ namespace fl
 		/// </summary>
 		/// <param name="name"> The component name to create. </param>
 		/// <returns> The new component. </returns>
-		Component *CreateComponent(const std::string &name) { return m_componentRegister->CreateComponent(name); }
+		std::shared_ptr<Component> CreateComponent(const std::string &name) { return m_componentRegister->CreateComponent(name); }
 
 		Scene *GetScene() const { return m_scene; }
 

--- a/Sources/Scenes/Scenes.hpp
+++ b/Sources/Scenes/Scenes.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Engine/Engine.hpp"
-#include "Objects/GameObject.hpp"
 #include "Objects/ComponentRegister.hpp"
 #include "SceneStructure.hpp"
 #include "Scene.hpp"

--- a/Sources/Shadows/RendererShadows.cpp
+++ b/Sources/Shadows/RendererShadows.cpp
@@ -9,20 +9,19 @@ namespace fl
 		IRenderer(),
 		m_pipeline(new Pipeline(graphicsStage, PipelineCreate({"Resources/Shaders/Shadows/Shadow.vert", "Resources/Shaders/Shadows/Shadow.frag"},
 			VertexModel::GetVertexInput(), PIPELINE_MODE_POLYGON_NO_DEPTH, PIPELINE_POLYGON_MODE_FILL, PIPELINE_CULL_MODE_FRONT), {})),
-		m_uniformScene(new UniformHandler())
+		m_uniformScene(UniformHandler())
 	{
 	}
 
 	RendererShadows::~RendererShadows()
 	{
 		delete m_pipeline;
-		delete m_uniformScene;
 	}
 
 	void RendererShadows::Render(const CommandBuffer &commandBuffer, const Vector4 &clipPlane, const ICamera &camera)
 	{
-		m_uniformScene->Push("projectionView", Shadows::Get()->GetShadowBox().GetProjectionViewMatrix());
-		m_uniformScene->Push("cameraPosition", camera.GetPosition());
+		m_uniformScene.Push("projectionView", Shadows::Get()->GetShadowBox().GetProjectionViewMatrix());
+		m_uniformScene.Push("cameraPosition", camera.GetPosition());
 
 		m_pipeline->BindPipeline(commandBuffer);
 

--- a/Sources/Shadows/RendererShadows.cpp
+++ b/Sources/Shadows/RendererShadows.cpp
@@ -21,7 +21,7 @@ namespace fl
 
 	void RendererShadows::Render(const CommandBuffer &commandBuffer, const Vector4 &clipPlane, const ICamera &camera)
 	{
-		m_uniformScene->Push("projectionView", *Shadows::Get()->GetShadowBox()->GetProjectionViewMatrix());
+		m_uniformScene->Push("projectionView", Shadows::Get()->GetShadowBox().GetProjectionViewMatrix());
 		m_uniformScene->Push("cameraPosition", camera.GetPosition());
 
 		m_pipeline->BindPipeline(commandBuffer);

--- a/Sources/Shadows/RendererShadows.cpp
+++ b/Sources/Shadows/RendererShadows.cpp
@@ -7,7 +7,7 @@ namespace fl
 {
 	RendererShadows::RendererShadows(const GraphicsStage &graphicsStage) :
 		IRenderer(),
-		m_pipeline(new Pipeline(graphicsStage, PipelineCreate({"Resources/Shaders/Shadows/Shadow.vert", "Resources/Shaders/Shadows/Shadow.frag"},
+		m_pipeline(Pipeline(graphicsStage, PipelineCreate({"Resources/Shaders/Shadows/Shadow.vert", "Resources/Shaders/Shadows/Shadow.frag"},
 			VertexModel::GetVertexInput(), PIPELINE_MODE_POLYGON_NO_DEPTH, PIPELINE_POLYGON_MODE_FILL, PIPELINE_CULL_MODE_FRONT), {})),
 		m_uniformScene(UniformHandler())
 	{
@@ -15,7 +15,6 @@ namespace fl
 
 	RendererShadows::~RendererShadows()
 	{
-		delete m_pipeline;
 	}
 
 	void RendererShadows::Render(const CommandBuffer &commandBuffer, const Vector4 &clipPlane, const ICamera &camera)
@@ -23,14 +22,13 @@ namespace fl
 		m_uniformScene.Push("projectionView", Shadows::Get()->GetShadowBox().GetProjectionViewMatrix());
 		m_uniformScene.Push("cameraPosition", camera.GetPosition());
 
-		m_pipeline->BindPipeline(commandBuffer);
+		m_pipeline.BindPipeline(commandBuffer);
 
-		std::vector<ShadowRender *> renderList = std::vector<ShadowRender *>();
-		Scenes::Get()->GetStructure()->QueryComponents<ShadowRender>(&renderList);
+		auto renderList = Scenes::Get()->GetStructure()->QueryComponents<ShadowRender>();
 
 		for (auto shadowRender : renderList)
 		{
-			shadowRender->CmdRender(commandBuffer, *m_pipeline, m_uniformScene);
+			shadowRender->CmdRender(commandBuffer, m_pipeline, m_uniformScene);
 		}
 	}
 }

--- a/Sources/Shadows/RendererShadows.cpp
+++ b/Sources/Shadows/RendererShadows.cpp
@@ -22,7 +22,7 @@ namespace fl
 	void RendererShadows::Render(const CommandBuffer &commandBuffer, const Vector4 &clipPlane, const ICamera &camera)
 	{
 		m_uniformScene->Push("projectionView", *Shadows::Get()->GetShadowBox()->GetProjectionViewMatrix());
-		m_uniformScene->Push("cameraPosition", *Scenes::Get()->GetCamera()->GetPosition());
+		m_uniformScene->Push("cameraPosition", camera.GetPosition());
 
 		m_pipeline->BindPipeline(commandBuffer);
 

--- a/Sources/Shadows/RendererShadows.hpp
+++ b/Sources/Shadows/RendererShadows.hpp
@@ -11,7 +11,7 @@ namespace fl
 		public IRenderer
 	{
 	private:
-		Pipeline *m_pipeline;
+		Pipeline m_pipeline;
 		UniformHandler m_uniformScene;
 	public:
 		RendererShadows(const GraphicsStage &graphicsStage);

--- a/Sources/Shadows/RendererShadows.hpp
+++ b/Sources/Shadows/RendererShadows.hpp
@@ -12,7 +12,7 @@ namespace fl
 	{
 	private:
 		Pipeline *m_pipeline;
-		UniformHandler *m_uniformScene;
+		UniformHandler m_uniformScene;
 	public:
 		RendererShadows(const GraphicsStage &graphicsStage);
 

--- a/Sources/Shadows/ShadowBox.cpp
+++ b/Sources/Shadows/ShadowBox.cpp
@@ -6,41 +6,30 @@
 namespace fl
 {
 	ShadowBox::ShadowBox() :
-		m_lightDirection(new Vector3()),
+		m_lightDirection(Vector3()),
 		m_shadowOffset(0.0f),
 		m_shadowDistance(0.0f),
-		m_projectionMatrix(new Matrix4()),
-		m_lightViewMatrix(new Matrix4()),
-		m_projectionViewMatrix(new Matrix4()),
-		m_shadowMapSpaceMatrix(new Matrix4()),
-		m_offset(new Matrix4(CreateOffset())),
-		m_centre(new Vector3()),
+		m_projectionMatrix(Matrix4()),
+		m_lightViewMatrix(Matrix4()),
+		m_projectionViewMatrix(Matrix4()),
+		m_shadowMapSpaceMatrix(Matrix4()),
+		m_offset(Matrix4(CreateOffset())),
+		m_centre(Vector3()),
 		m_farHeight(0.0f),
 		m_farWidth(0.0f),
 		m_nearHeight(0.0f),
 		m_nearWidth(0.0f),
-		m_aabb(new ColliderAabb())
+		m_aabb(ColliderAabb())
 	{
 	}
 
 	ShadowBox::~ShadowBox()
 	{
-		delete m_lightDirection;
-
-		delete m_projectionMatrix;
-		delete m_lightViewMatrix;
-		delete m_projectionViewMatrix;
-		delete m_shadowMapSpaceMatrix;
-		delete m_offset;
-		delete m_centre;
-
-		delete m_aabb;
 	}
 
 	void ShadowBox::Update(const ICamera &camera, const Vector3 &lightPosition, const float &shadowOffset, const float &shadowDistance)
 	{
-		*m_lightDirection = lightPosition;
-		m_lightDirection->Normalize();
+		m_lightDirection = lightPosition.Normalize();
 		m_shadowOffset = shadowOffset;
 		m_shadowDistance = shadowDistance;
 
@@ -75,7 +64,7 @@ namespace fl
 		Vector3 centreNear = toNear + camera.GetPosition();
 		Vector3 centreFar = toFar + camera.GetPosition();
 
-		Vector4 *points = CalculateFrustumVertices(rotation, forwardVector, centreNear, centreFar);
+		auto points = CalculateFrustumVertices(rotation, forwardVector, centreNear, centreFar);
 
 		for (int i = 0; i < 8; i++)
 		{
@@ -83,47 +72,45 @@ namespace fl
 
 			if (i == 0)
 			{
-				m_aabb->m_minExtents->m_x = point.m_x;
-				m_aabb->m_maxExtents->m_x = point.m_x;
-				m_aabb->m_minExtents->m_y = point.m_y;
-				m_aabb->m_maxExtents->m_y = point.m_y;
-				m_aabb->m_minExtents->m_z = point.m_z;
-				m_aabb->m_maxExtents->m_z = point.m_z;
+				m_aabb.m_minExtents.m_x = point.m_x;
+				m_aabb.m_maxExtents.m_x = point.m_x;
+				m_aabb.m_minExtents.m_y = point.m_y;
+				m_aabb.m_maxExtents.m_y = point.m_y;
+				m_aabb.m_minExtents.m_z = point.m_z;
+				m_aabb.m_maxExtents.m_z = point.m_z;
 			}
 			else
 			{
-				if (point.m_x > m_aabb->m_maxExtents->m_x)
+				if (point.m_x > m_aabb.m_maxExtents.m_x)
 				{
-					m_aabb->m_maxExtents->m_x = point.m_x;
+					m_aabb.m_maxExtents.m_x = point.m_x;
 				}
-				else if (point.m_x < m_aabb->m_minExtents->m_x)
+				else if (point.m_x < m_aabb.m_minExtents.m_x)
 				{
-					m_aabb->m_minExtents->m_x = point.m_x;
-				}
-
-				if (point.m_y > m_aabb->m_maxExtents->m_y)
-				{
-					m_aabb->m_maxExtents->m_y = point.m_y;
-				}
-				else if (point.m_y < m_aabb->m_minExtents->m_y)
-				{
-					m_aabb->m_minExtents->m_y = point.m_y;
+					m_aabb.m_minExtents.m_x = point.m_x;
 				}
 
-				if (point.m_z > m_aabb->m_maxExtents->m_z)
+				if (point.m_y > m_aabb.m_maxExtents.m_y)
 				{
-					m_aabb->m_maxExtents->m_z = point.m_z;
+					m_aabb.m_maxExtents.m_y = point.m_y;
 				}
-				else if (point.m_z < m_aabb->m_minExtents->m_z)
+				else if (point.m_y < m_aabb.m_minExtents.m_y)
 				{
-					m_aabb->m_minExtents->m_z = point.m_z;
+					m_aabb.m_minExtents.m_y = point.m_y;
+				}
+
+				if (point.m_z > m_aabb.m_maxExtents.m_z)
+				{
+					m_aabb.m_maxExtents.m_z = point.m_z;
+				}
+				else if (point.m_z < m_aabb.m_minExtents.m_z)
+				{
+					m_aabb.m_minExtents.m_z = point.m_z;
 				}
 			}
 		}
 
-		m_aabb->m_maxExtents->m_z += m_shadowOffset;
-
-		delete[] points;
+		m_aabb.m_maxExtents.m_z += m_shadowOffset;
 	}
 
 	void ShadowBox::UpdateSizes(const ICamera &camera)
@@ -134,7 +121,7 @@ namespace fl
 		m_nearHeight = m_nearWidth / Display::Get()->GetAspectRatio();
 	}
 
-	Vector4 *ShadowBox::CalculateFrustumVertices(const Matrix4 &rotation, const Vector3 &forwardVector, const Vector3 &centreNear, const Vector3 &centreFar) const
+	std::array<Vector4, 8> ShadowBox::CalculateFrustumVertices(const Matrix4 &rotation, const Vector3 &forwardVector, const Vector3 &centreNear, const Vector3 &centreFar)
 	{
 		Vector4 upVector4 = rotation.Transform(Vector4(0.0f, 1.0f, 0.0f, 0.0f));
 		Vector3 upVector = Vector3(upVector4);
@@ -152,7 +139,7 @@ namespace fl
 		Vector3 nearTop = centreNear + nearUpVector;
 		Vector3 nearBottom = centreNear + nearDownVector;
 
-		Vector4 *points = new Vector4[8];
+		auto points = std::array<Vector4, 8>();
 		points[0] = CalculateLightSpaceFrustumCorner(farTop, rightVector, m_farWidth);
 		points[1] = CalculateLightSpaceFrustumCorner(farTop, leftVector, m_farWidth);
 		points[2] = CalculateLightSpaceFrustumCorner(farBottom, rightVector, m_farWidth);
@@ -164,71 +151,66 @@ namespace fl
 		return points;
 	}
 
-	Vector4 ShadowBox::CalculateLightSpaceFrustumCorner(const Vector3 &startPoint, const Vector3 &direction, const float &width) const
+	Vector4 ShadowBox::CalculateLightSpaceFrustumCorner(const Vector3 &startPoint, const Vector3 &direction, const float &width)
 	{
 		Vector3 point = startPoint + (direction * width);
 		Vector4 point4 = Vector4(point);
-		point4 = m_lightViewMatrix->Transform(point4);
+		point4 = m_lightViewMatrix.Transform(point4);
 		return point4;
 	}
 
-	void ShadowBox::UpdateOrthoProjectionMatrix() const
+	void ShadowBox::UpdateOrthoProjectionMatrix()
 	{
-		m_projectionMatrix->SetIdentity();
-		m_projectionMatrix->m_00 = 2.0f / m_aabb->GetWidth();
-		m_projectionMatrix->m_11 = 2.0f / m_aabb->GetHeight();
-		m_projectionMatrix->m_22 = -2.0f / m_aabb->GetDepth();
-		m_projectionMatrix->m_33 = 1.0f;
+		m_projectionMatrix = m_projectionMatrix.SetIdentity();
+		m_projectionMatrix.m_00 = 2.0f / m_aabb.GetWidth();
+		m_projectionMatrix.m_11 = 2.0f / m_aabb.GetHeight();
+		m_projectionMatrix.m_22 = -2.0f / m_aabb.GetDepth();
+		m_projectionMatrix.m_33 = 1.0f;
 	}
 
-	void ShadowBox::UpdateCenter() const
+	void ShadowBox::UpdateCenter()
 	{
-		float x = (m_aabb->m_minExtents->m_x + m_aabb->m_maxExtents->m_x) / 2.0f;
-		float y = (m_aabb->m_minExtents->m_y + m_aabb->m_maxExtents->m_y) / 2.0f;
-		float z = (m_aabb->m_minExtents->m_z + m_aabb->m_maxExtents->m_z) / 2.0f;
+		float x = (m_aabb.m_minExtents.m_x + m_aabb.m_maxExtents.m_x) / 2.0f;
+		float y = (m_aabb.m_minExtents.m_y + m_aabb.m_maxExtents.m_y) / 2.0f;
+		float z = (m_aabb.m_minExtents.m_z + m_aabb.m_maxExtents.m_z) / 2.0f;
 		Vector4 centre = Vector4(x, y, z, 1.0f);
-		Matrix4 invertedLight = m_lightViewMatrix->Invert();
-		Vector4 centre4 = invertedLight.Transform(centre);
+		Matrix4 invertedLight = m_lightViewMatrix.Invert();
 
-		*m_centre = centre4;
+		m_centre = invertedLight.Transform(centre);
 	}
 
-	void ShadowBox::UpdateLightViewMatrix() const
+	void ShadowBox::UpdateLightViewMatrix()
 	{
-		m_centre->Negate();
+		m_lightViewMatrix = m_lightViewMatrix.SetIdentity();
+		float pitch = std::acos(Vector2(m_lightDirection.m_x, m_lightDirection.m_z).Length());
+		m_lightViewMatrix = m_lightViewMatrix.Rotate(pitch, Vector3::RIGHT);
+		float yaw = Maths::Degrees(std::atan(m_lightDirection.m_x / m_lightDirection.m_z));
 
-		m_lightViewMatrix->SetIdentity();
-		float pitch = std::acos(Vector2(m_lightDirection->m_x, m_lightDirection->m_z).Length());
-		*m_lightViewMatrix = m_lightViewMatrix->Rotate(pitch, Vector3::RIGHT);
-		float yaw = Maths::Degrees(std::atan(m_lightDirection->m_x / m_lightDirection->m_z));
-
-		if (m_lightDirection->m_z > 0.0f)
+		if (m_lightDirection.m_z > 0.0f)
 		{
 			yaw -= 180.0f;
 		}
 
-		*m_lightViewMatrix = m_lightViewMatrix->Rotate(-Maths::Radians(yaw), Vector3::UP);
-		*m_lightViewMatrix = m_lightViewMatrix->Translate(*m_centre);
-
-		m_centre->Negate();
+		m_lightViewMatrix = m_lightViewMatrix.Rotate(-Maths::Radians(yaw), Vector3::UP);
+		m_lightViewMatrix = m_lightViewMatrix.Translate(-m_centre);
 	}
 
-	void ShadowBox::UpdateViewShadowMatrix() const
+	void ShadowBox::UpdateViewShadowMatrix()
 	{
-		m_projectionViewMatrix->SetIdentity();
-		m_shadowMapSpaceMatrix->SetIdentity();
-		*m_projectionViewMatrix = *m_projectionMatrix * *m_lightViewMatrix;
-		*m_shadowMapSpaceMatrix = *m_offset * *m_projectionViewMatrix;
+		m_projectionViewMatrix = m_projectionViewMatrix.SetIdentity();
+		m_shadowMapSpaceMatrix = m_shadowMapSpaceMatrix.SetIdentity();
+		m_projectionViewMatrix = m_projectionMatrix * m_lightViewMatrix;
+		m_shadowMapSpaceMatrix = m_offset * m_projectionViewMatrix;
 	}
 
 	bool ShadowBox::IsInBox(const Vector3 &position, const float &radius) const
 	{
-		Vector4 entityPos = m_lightViewMatrix->Transform(Vector4(position));
+		Vector4 entityPos = m_lightViewMatrix.Transform(Vector4(position));
 
 		Vector3 closestPoint = Vector3();
-		closestPoint.m_x = Maths::Clamp(entityPos.m_x, m_aabb->m_minExtents->m_x, m_aabb->m_maxExtents->m_x);
-		closestPoint.m_y = Maths::Clamp(entityPos.m_y, m_aabb->m_minExtents->m_y, m_aabb->m_maxExtents->m_y);
-		closestPoint.m_z = Maths::Clamp(entityPos.m_z, m_aabb->m_minExtents->m_z, m_aabb->m_maxExtents->m_z);
+		closestPoint.m_x = Maths::Clamp(entityPos.m_x, m_aabb.m_minExtents.m_x, m_aabb.m_maxExtents.m_x);
+		closestPoint.m_y = Maths::Clamp(entityPos.m_y, m_aabb.m_minExtents.m_y, m_aabb.m_maxExtents.m_y);
+		closestPoint.m_z = Maths::Clamp(entityPos.m_z, m_aabb.m_minExtents.m_z, m_aabb.m_maxExtents.m_z);
 
 		Vector3 centre = Vector3(entityPos);
 		Vector3 distance = centre - closestPoint;

--- a/Sources/Shadows/ShadowBox.cpp
+++ b/Sources/Shadows/ShadowBox.cpp
@@ -64,16 +64,16 @@ namespace fl
 		UpdateSizes(camera);
 
 		Matrix4 rotation = Matrix4();
-		rotation = rotation.Rotate(Maths::Radians(camera.GetRotation()->m_y), Vector3::UP);
-		rotation = rotation.Rotate(Maths::Radians(camera.GetRotation()->m_x), Vector3::RIGHT);
+		rotation = rotation.Rotate(Maths::Radians(camera.GetRotation().m_y), Vector3::UP);
+		rotation = rotation.Rotate(Maths::Radians(camera.GetRotation().m_x), Vector3::RIGHT);
 
 		Vector4 forwardVector4 = rotation.Transform(Vector4(0.0f, 0.0f, -1.0f, 0.0f));
 		Vector3 forwardVector = Vector3(forwardVector4);
 
 		Vector3 toFar = forwardVector * m_shadowDistance;
 		Vector3 toNear = forwardVector * camera.GetNearPlane();
-		Vector3 centreNear = toNear + *camera.GetPosition();
-		Vector3 centreFar = toFar + *camera.GetPosition();
+		Vector3 centreNear = toNear + camera.GetPosition();
+		Vector3 centreFar = toFar + camera.GetPosition();
 
 		Vector4 *points = CalculateFrustumVertices(rotation, forwardVector, centreNear, centreFar);
 

--- a/Sources/Shadows/ShadowBox.hpp
+++ b/Sources/Shadows/ShadowBox.hpp
@@ -15,21 +15,21 @@ namespace fl
 	class FL_EXPORT ShadowBox
 	{
 	private:
-		Vector3 *m_lightDirection;
+		Vector3 m_lightDirection;
 		float m_shadowOffset;
 		float m_shadowDistance;
 
-		Matrix4 *m_projectionMatrix;
-		Matrix4 *m_lightViewMatrix;
-		Matrix4 *m_projectionViewMatrix;
-		Matrix4 *m_shadowMapSpaceMatrix;
-		Matrix4 *m_offset;
-		Vector3 *m_centre;
+		Matrix4 m_projectionMatrix;
+		Matrix4 m_lightViewMatrix;
+		Matrix4 m_projectionViewMatrix;
+		Matrix4 m_shadowMapSpaceMatrix;
+		Matrix4 m_offset;
+		Vector3 m_centre;
 
 		float m_farHeight, m_farWidth;
 		float m_nearHeight, m_nearWidth;
 
-		ColliderAabb *m_aabb;
+		ColliderAabb m_aabb;
 	public:
 		/// <summary>
 		/// Creates a new shadow box and calculates some initial values relating to the camera's view frustum.
@@ -73,7 +73,7 @@ namespace fl
 		/// <param name="centreFar"> - the centre point of the frustum's far plane.
 		/// </param>
 		/// <returns> The vertices of the frustum in light space. </returns>
-		Vector4 *CalculateFrustumVertices(const Matrix4 &rotation, const Vector3 &forwardVector, const Vector3 &centreNear, const Vector3 &centreFar) const;
+		std::array<Vector4, 8> CalculateFrustumVertices(const Matrix4 &rotation, const Vector3 &forwardVector, const Vector3 &centreNear, const Vector3 &centreFar);
 
 		/// <summary>
 		/// Calculates one of the corner vertices of the view frustum in world space and converts it to light space.
@@ -83,18 +83,18 @@ namespace fl
 		/// <param name="width"> The distance of the corner from the start point.
 		/// </param>
 		/// <returns> The relevant corner vertex of the view frustum in light space. </returns>
-		Vector4 CalculateLightSpaceFrustumCorner(const Vector3 &startPoint, const Vector3 &direction, const float &width) const;
+		Vector4 CalculateLightSpaceFrustumCorner(const Vector3 &startPoint, const Vector3 &direction, const float &width);
 
-		void UpdateOrthoProjectionMatrix() const;
+		void UpdateOrthoProjectionMatrix();
 
 		/// <summary>
 		/// Updates the centre of the shadow box (orthographic projection area).
 		/// </summary>
-		void UpdateCenter() const;
+		void UpdateCenter();
 
-		void UpdateLightViewMatrix() const;
+		void UpdateLightViewMatrix();
 
-		void UpdateViewShadowMatrix() const;
+		void UpdateViewShadowMatrix();
 
 	public:
 		/// <summary>
@@ -106,20 +106,20 @@ namespace fl
 		/// <returns> {@code true} if the sphere intersects the box. </returns>
 		bool IsInBox(const Vector3 &position, const float &radius) const;
 
-		Matrix4 *GetProjectionViewMatrix() const { return m_projectionViewMatrix; }
+		Matrix4 GetProjectionViewMatrix() const { return m_projectionViewMatrix; }
 
 		/// <summary>
 		/// This biased projection-view matrix is used to convert fragments into "shadow map space" when rendering the main render pass.
 		/// </summary>
 		/// <returns> The to-shadow-map-space matrix. </returns>
-		Matrix4 *GetToShadowMapSpaceMatrix() const { return m_shadowMapSpaceMatrix; }
+		Matrix4 GetToShadowMapSpaceMatrix() const { return m_shadowMapSpaceMatrix; }
 
 		/// <summary>
 		/// Gets the light's "view" matrix
 		/// </summary>
 		/// <returns> The light's "view" matrix. </returns>
-		Matrix4 *GetLightSpaceTransform() const { return m_lightViewMatrix; }
+		Matrix4 GetLightSpaceTransform() const { return m_lightViewMatrix; }
 
-		ColliderAabb *GetAabb() const { return m_aabb; }
+		ColliderAabb GetAabb() const { return m_aabb; }
 	};
 }

--- a/Sources/Shadows/ShadowRender.cpp
+++ b/Sources/Shadows/ShadowRender.cpp
@@ -6,21 +6,19 @@ namespace fl
 {
 	ShadowRender::ShadowRender() :
 		Component(),
-		m_descriptorSet(new DescriptorsHandler()),
-		m_uniformObject(new UniformHandler())
+		m_descriptorSet(DescriptorsHandler()),
+		m_uniformObject(UniformHandler())
 	{
 	}
 
 	ShadowRender::~ShadowRender()
 	{
-		delete m_descriptorSet;
-		delete m_uniformObject;
 	}
 
 	void ShadowRender::Update()
 	{
 		// Updates uniforms.
-		m_uniformObject->Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
+		m_uniformObject.Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
 	}
 
 	void ShadowRender::Load(LoadedValue *value)
@@ -31,7 +29,7 @@ namespace fl
 	{
 	}
 
-	void ShadowRender::CmdRender(const CommandBuffer &commandBuffer, const Pipeline &pipeline, UniformHandler *uniformScene)
+	void ShadowRender::CmdRender(const CommandBuffer &commandBuffer, const Pipeline &pipeline, UniformHandler &uniformScene)
 	{
 		// Gets required components.
 		auto mesh = GetGameObject()->GetComponent<Mesh>();
@@ -42,17 +40,17 @@ namespace fl
 		}
 
 		// Updates descriptors.
-		m_descriptorSet->Push("UboScene", uniformScene);
-		m_descriptorSet->Push("UboObject", m_uniformObject);
-		bool descriptorsSet = m_descriptorSet->Update(pipeline);
+		m_descriptorSet.Push("UboScene", uniformScene);
+		m_descriptorSet.Push("UboObject", m_uniformObject);
+		bool updateSuccess = m_descriptorSet.Update(pipeline);
 
-		if (!descriptorsSet)
+		if (!updateSuccess)
 		{
 			return;
 		}
 
 		// Draws the object.
-		m_descriptorSet->GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
 		mesh->GetModel()->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Shadows/ShadowRender.cpp
+++ b/Sources/Shadows/ShadowRender.cpp
@@ -50,7 +50,7 @@ namespace fl
 		}
 
 		// Draws the object.
-		m_descriptorSet.GetDescriptorSet()->BindDescriptor(commandBuffer);
+		m_descriptorSet.BindDescriptor(commandBuffer);
 		mesh->GetModel()->CmdRender(commandBuffer);
 	}
 }

--- a/Sources/Shadows/ShadowRender.hpp
+++ b/Sources/Shadows/ShadowRender.hpp
@@ -14,8 +14,8 @@ namespace fl
 		public Component
 	{
 	private:
-		DescriptorsHandler *m_descriptorSet;
-		UniformHandler *m_uniformObject;
+		DescriptorsHandler m_descriptorSet;
+		UniformHandler m_uniformObject;
 	public:
 		ShadowRender();
 
@@ -27,10 +27,10 @@ namespace fl
 
 		void Write(LoadedValue *value) override;
 
-		void CmdRender(const CommandBuffer &commandBuffer, const Pipeline &pipeline, UniformHandler *uniformScene);
+		void CmdRender(const CommandBuffer &commandBuffer, const Pipeline &pipeline, UniformHandler &uniformScene);
 
 		std::string GetName() const override { return "ShadowRender"; };
 
-		UniformHandler *GetUniformObject() const { return m_uniformObject; }
+		UniformHandler GetUniformObject() const { return m_uniformObject; }
 	};
 }

--- a/Sources/Shadows/Shadows.cpp
+++ b/Sources/Shadows/Shadows.cpp
@@ -6,7 +6,7 @@ namespace fl
 {
 	Shadows::Shadows() :
 		IModule(),
-		m_lightDirection(new Vector3(0.5f, 0.0f, 0.5f)),
+		m_lightDirection(Vector3(0.5f, 0.0f, 0.5f)),
 		m_shadowSize(8192),
 		m_shadowPcf(1),
 		m_shadowBias(0.001f),
@@ -14,21 +14,19 @@ namespace fl
 		m_shadowTransition(11.0f),
 		m_shadowBoxOffset(9.0f),
 		m_shadowBoxDistance(70.0f),
-		m_shadowBox(new ShadowBox())
+		m_shadowBox(ShadowBox())
 	{
 	}
 
 	Shadows::~Shadows()
 	{
-		delete m_lightDirection;
-		delete m_shadowBox;
 	}
 
 	void Shadows::Update()
 	{
 		if (Scenes::Get()->GetCamera() != nullptr)
 		{
-			m_shadowBox->Update(*Scenes::Get()->GetCamera(), *m_lightDirection, m_shadowBoxOffset, m_shadowBoxDistance);
+			m_shadowBox.Update(*Scenes::Get()->GetCamera(), m_lightDirection, m_shadowBoxOffset, m_shadowBoxDistance);
 		}
 	}
 }

--- a/Sources/Shadows/Shadows.hpp
+++ b/Sources/Shadows/Shadows.hpp
@@ -13,7 +13,7 @@ namespace fl
 		public IModule
 	{
 	private:
-		Vector3 *m_lightDirection;
+		Vector3 m_lightDirection;
 
 		uint32_t m_shadowSize;
 		int m_shadowPcf;
@@ -24,7 +24,7 @@ namespace fl
 		float m_shadowBoxOffset;
 		float m_shadowBoxDistance;
 
-		ShadowBox *m_shadowBox;
+		ShadowBox m_shadowBox;
 	public:
 		/// <summary>
 		/// Gets this engine instance.
@@ -47,9 +47,9 @@ namespace fl
 
 		void Update() override;
 
-		Vector3 *GetLightDirection() const { return m_lightDirection; }
+		Vector3 GetLightDirection() const { return m_lightDirection; }
 
-		void SetLightDirection(const Vector3 &lightDirection) { *m_lightDirection = lightDirection; }
+		void SetLightDirection(const Vector3 &lightDirection) { m_lightDirection = lightDirection; }
 
 		uint32_t GetShadowSize() const { return m_shadowSize; }
 
@@ -83,6 +83,6 @@ namespace fl
 		/// Get the shadow box, so that it can be used by other class to test if engine.entities are inside the box.
 		/// </summary>
 		/// <returns> The shadow box. </returns>
-		ShadowBox *GetShadowBox() const { return m_shadowBox; }
+		ShadowBox GetShadowBox() const { return m_shadowBox; }
 	};
 }

--- a/Sources/Skyboxes/CelestialBody.cpp
+++ b/Sources/Skyboxes/CelestialBody.cpp
@@ -24,10 +24,10 @@ namespace fl
 			switch (m_type)
 			{
 			case CELESTIAL_SUN:
-				entityTransform->SetPosition(*Worlds::Get()->GetSunPosition());
+				entityTransform->SetPosition(Worlds::Get()->GetSunPosition());
 				break;
 			case CELESTIAL_MOON:
-				entityTransform->SetPosition(*Worlds::Get()->GetMoonPosition());
+				entityTransform->SetPosition(Worlds::Get()->GetMoonPosition());
 				break;
 			}
 		}
@@ -39,10 +39,10 @@ namespace fl
 			switch (m_type)
 			{
 			case CELESTIAL_SUN:
-				componentLight->SetColour(*Worlds::Get()->GetSunColour());
+				componentLight->SetColour(Worlds::Get()->GetSunColour());
 				break;
 			case CELESTIAL_MOON:
-				componentLight->SetColour(*Worlds::Get()->GetMoonColour());
+				componentLight->SetColour(Worlds::Get()->GetMoonColour());
 				break;
 			}
 		}

--- a/Sources/Skyboxes/CelestialBody.hpp
+++ b/Sources/Skyboxes/CelestialBody.hpp
@@ -17,7 +17,7 @@ namespace fl
 	private:
 		CelestialType m_type;
 	public:
-		CelestialBody(const CelestialType &type = CelestialType::CELESTIAL_SUN);
+		CelestialBody(const CelestialType &type = CELESTIAL_SUN);
 
 		~CelestialBody();
 

--- a/Sources/Skyboxes/MaterialSkybox.cpp
+++ b/Sources/Skyboxes/MaterialSkybox.cpp
@@ -25,7 +25,7 @@ namespace fl
 
 		if (m_enableFog)
 		{
-			GetGameObject()->GetTransform()->SetRotation(*Worlds::Get()->GetSkyboxRotation());
+			GetGameObject()->GetTransform()->SetRotation(Worlds::Get()->GetSkyboxRotation());
 			m_blend = Worlds::Get()->GetStarIntensity();
 		}
 	}
@@ -45,13 +45,13 @@ namespace fl
 	void MaterialSkybox::PushUniforms(UniformHandler *uniformObject)
 	{
 		uniformObject->Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
-		uniformObject->Push("skyColour", *Worlds::Get()->GetSkyColour());
-		uniformObject->Push("fogColour", Worlds::Get()->GetFog()->GetColour());
+		uniformObject->Push("skyColour", Worlds::Get()->GetSkyColour());
+		uniformObject->Push("fogColour", Worlds::Get()->GetFog().GetColour());
 
 		// Updates uniforms.
 		if (m_enableFog)
 		{
-			uniformObject->Push("fogLimits", GetGameObject()->GetTransform()->GetScaling().m_y * Vector2(Worlds::Get()->GetFog()->GetLowerLimit(), Worlds::Get()->GetFog()->GetUpperLimit()));
+			uniformObject->Push("fogLimits", GetGameObject()->GetTransform()->GetScaling().m_y * Vector2(Worlds::Get()->GetFog().GetLowerLimit(), Worlds::Get()->GetFog().GetUpperLimit()));
 			uniformObject->Push("blendFactor", m_blend);
 		}
 		else

--- a/Sources/Skyboxes/MaterialSkybox.cpp
+++ b/Sources/Skyboxes/MaterialSkybox.cpp
@@ -5,7 +5,7 @@
 
 namespace fl
 {
-	MaterialSkybox::MaterialSkybox(Cubemap *cubemap, const bool &enableFog) :
+	MaterialSkybox::MaterialSkybox(std::shared_ptr<Cubemap> cubemap, const bool &enableFog) :
 		IMaterial(),
 		m_cubemap(cubemap),
 		m_enableFog(enableFog),
@@ -46,12 +46,12 @@ namespace fl
 	{
 		uniformObject->Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
 		uniformObject->Push("skyColour", *Worlds::Get()->GetSkyColour());
-		uniformObject->Push("fogColour", *Worlds::Get()->GetFog()->GetColour());
+		uniformObject->Push("fogColour", Worlds::Get()->GetFog()->GetColour());
 
 		// Updates uniforms.
 		if (m_enableFog)
 		{
-			uniformObject->Push("fogLimits", GetGameObject()->GetTransform()->GetScaling()->m_y * Vector2(Worlds::Get()->GetFog()->GetLowerLimit(), Worlds::Get()->GetFog()->GetUpperLimit()));
+			uniformObject->Push("fogLimits", GetGameObject()->GetTransform()->GetScaling().m_y * Vector2(Worlds::Get()->GetFog()->GetLowerLimit(), Worlds::Get()->GetFog()->GetUpperLimit()));
 			uniformObject->Push("blendFactor", m_blend);
 		}
 		else

--- a/Sources/Skyboxes/MaterialSkybox.cpp
+++ b/Sources/Skyboxes/MaterialSkybox.cpp
@@ -42,27 +42,26 @@ namespace fl
 		destination->GetChild("Enable Fog", true)->Set((int) m_enableFog);
 	}
 
-	void MaterialSkybox::PushUniforms(UniformHandler *uniformObject)
+	void MaterialSkybox::PushUniforms(UniformHandler &uniformObject)
 	{
-		uniformObject->Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
-		uniformObject->Push("skyColour", Worlds::Get()->GetSkyColour());
-		uniformObject->Push("fogColour", Worlds::Get()->GetFog().GetColour());
+		uniformObject.Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
+		uniformObject.Push("skyColour", Worlds::Get()->GetSkyColour());
+		uniformObject.Push("fogColour", Worlds::Get()->GetFog().GetColour());
 
-		// Updates uniforms.
 		if (m_enableFog)
 		{
-			uniformObject->Push("fogLimits", GetGameObject()->GetTransform()->GetScaling().m_y * Vector2(Worlds::Get()->GetFog().GetLowerLimit(), Worlds::Get()->GetFog().GetUpperLimit()));
-			uniformObject->Push("blendFactor", m_blend);
+			uniformObject.Push("fogLimits", GetGameObject()->GetTransform()->GetScaling().m_y * Vector2(Worlds::Get()->GetFog().GetLowerLimit(), Worlds::Get()->GetFog().GetUpperLimit()));
+			uniformObject.Push("blendFactor", m_blend);
 		}
 		else
 		{
-			uniformObject->Push("fogLimits", Vector2(-1000000.0f, -1000000.0f));
-			uniformObject->Push("blendFactor", 1.0f);
+			uniformObject.Push("fogLimits", Vector2(-1000000.0f, -1000000.0f));
+			uniformObject.Push("blendFactor", 1.0f);
 		}
 	}
 
-	void MaterialSkybox::PushDescriptors(DescriptorsHandler *descriptorSet)
+	void MaterialSkybox::PushDescriptors(DescriptorsHandler &descriptorSet)
 	{
-		descriptorSet->Push("samplerCubemap", m_cubemap);
+		descriptorSet.Push("samplerCubemap", m_cubemap);
 	}
 }

--- a/Sources/Skyboxes/MaterialSkybox.cpp
+++ b/Sources/Skyboxes/MaterialSkybox.cpp
@@ -21,7 +21,7 @@ namespace fl
 
 	void MaterialSkybox::Update()
 	{
-		GetGameObject()->GetTransform()->SetPosition(*Scenes::Get()->GetCamera()->GetPosition());
+		GetGameObject()->GetTransform()->SetPosition(Scenes::Get()->GetCamera()->GetPosition());
 
 		if (m_enableFog)
 		{

--- a/Sources/Skyboxes/MaterialSkybox.hpp
+++ b/Sources/Skyboxes/MaterialSkybox.hpp
@@ -12,14 +12,14 @@ namespace fl
 		public IMaterial
 	{
 	private:
-		Cubemap *m_cubemap;
+		std::shared_ptr<Cubemap> m_cubemap;
 		bool m_enableFog;
 
 		float m_blend;
 
-		PipelineMaterial *m_material;
+		std::shared_ptr<PipelineMaterial> m_material;
 	public:
-		MaterialSkybox(Cubemap *cubemap = nullptr, const bool &enableFog = true);
+		MaterialSkybox(std::shared_ptr<Cubemap> cubemap = nullptr, const bool &enableFog = true);
 
 		~MaterialSkybox();
 
@@ -35,9 +35,9 @@ namespace fl
 
 		std::string GetName() const override { return "MaterialSkybox"; };
 
-		Cubemap *GetCubemap() const { return m_cubemap; }
+		std::shared_ptr<Cubemap> GetCubemap() const { return m_cubemap; }
 
-		void SetCubemap(Cubemap *cubemap) { m_cubemap = cubemap; }
+		void SetCubemap(std::shared_ptr<Cubemap> cubemap) { m_cubemap = cubemap; }
 
 		void TrySetCubemap(const std::string &filename)
 		{
@@ -51,6 +51,6 @@ namespace fl
 
 		void SetBlend(const float blend) { m_blend = blend; }
 
-		PipelineMaterial *GetMaterial() const override { return m_material; }
+		std::shared_ptr<PipelineMaterial> GetMaterial() const override { return m_material; }
 	};
 }

--- a/Sources/Skyboxes/MaterialSkybox.hpp
+++ b/Sources/Skyboxes/MaterialSkybox.hpp
@@ -29,9 +29,9 @@ namespace fl
 
 		void Write(LoadedValue *destination) override;
 
-		void PushUniforms(UniformHandler *uniformObject) override;
+		void PushUniforms(UniformHandler &uniformObject) override;
 
-		void PushDescriptors(DescriptorsHandler *descriptorSet) override;
+		void PushDescriptors(DescriptorsHandler &descriptorSet) override;
 
 		std::string GetName() const override { return "MaterialSkybox"; };
 

--- a/Sources/Tasks/Tasks.cpp
+++ b/Sources/Tasks/Tasks.cpp
@@ -24,6 +24,6 @@ namespace fl
 
 	void Tasks::AddTask(std::function<void()> task)
 	{
-		m_tasks.push_back(task);
+		m_tasks.emplace_back(task);
 	}
 }

--- a/Sources/Tasks/Tasks.cpp
+++ b/Sources/Tasks/Tasks.cpp
@@ -4,27 +4,26 @@ namespace fl
 {
 	Tasks::Tasks() :
 		IModule(),
-		m_tasks(new std::vector<std::function<void()>>())
+		m_tasks(std::vector<std::function<void()>>())
 	{
 	}
 
 	Tasks::~Tasks()
 	{
-		delete m_tasks;
 	}
 
 	void Tasks::Update()
 	{
-		for (auto it = m_tasks->begin(); it != m_tasks->end(); ++it)
+		for (auto it = m_tasks.begin(); it != m_tasks.end(); ++it)
 		{
 			(*it)();
 		}
 
-		m_tasks->clear();
+		m_tasks.clear();
 	}
 
-	void Tasks::AddTask(std::function<void()> task) const
+	void Tasks::AddTask(std::function<void()> task)
 	{
-		m_tasks->push_back(task);
+		m_tasks.push_back(task);
 	}
 }

--- a/Sources/Tasks/Tasks.hpp
+++ b/Sources/Tasks/Tasks.hpp
@@ -13,7 +13,7 @@ namespace fl
 		public IModule
 	{
 	private:
-		std::vector<std::function<void()>> *m_tasks;
+		std::vector<std::function<void()>> m_tasks;
 	public:
 		/// <summary>
 		/// Gets this engine instance.
@@ -34,6 +34,6 @@ namespace fl
 		/// Adds an task to the que.
 		/// </summary>
 		/// <param name="task"> The task to add. </param>
-		void AddTask(std::function<void()> task) const;
+		void AddTask(std::function<void()> task);
 	};
 }

--- a/Sources/Textures/Cubemap.cpp
+++ b/Sources/Textures/Cubemap.cpp
@@ -64,6 +64,70 @@ namespace fl
 #endif
 	}
 
+	Cubemap::Cubemap(const uint32_t &width, const uint32_t &height, const VkFormat &format, const VkImageLayout &imageLayout, const VkImageUsageFlags &usage, float *pixels) :
+		IResource(),
+		Buffer(width * height * 4 * 6, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT),
+		IDescriptor(),
+		m_filename(""),
+		m_fileExt(""),
+		m_mipLevels(1),
+		m_components(0),
+		m_width(0),
+		m_height(0),
+		m_depth(0),
+		m_image(VK_NULL_HANDLE),
+		m_imageView(VK_NULL_HANDLE),
+		m_format(VK_FORMAT_R8G8B8A8_UNORM),
+		m_imageInfo({})
+	{
+#if FL_VERBOSE
+		const auto debugStart = Engine::Get()->GetTimeMs();
+#endif
+
+		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+
+		Buffer *bufferStaging = new Buffer(m_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+
+		if (pixels == nullptr)
+		{
+			pixels = new float[width * height * 6]();
+
+			for (uint32_t i = 0; i < width * height * 6; i++)
+			{
+				pixels[i] = 0.0f;
+			}
+		}
+
+		void *data;
+		vkMapMemory(logicalDevice, bufferStaging->GetVkBufferMemory(), 0, m_size, 0, &data);
+		memcpy(data, pixels, m_size);
+		vkUnmapMemory(logicalDevice, bufferStaging->GetVkBufferMemory());
+
+		Texture::CreateImage(m_width, m_height, m_depth, m_mipLevels, m_format, VK_IMAGE_TILING_OPTIMAL,
+			VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, m_image, m_bufferMemory, 6);
+		Texture::TransitionImageLayout(m_image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, 6);
+		Texture::CopyBufferToImage(m_width, m_height, m_depth, bufferStaging->GetVkBuffer(), m_image, 6);
+		Texture::CreateMipmaps(m_image, m_width, m_height, m_depth, m_mipLevels, 6);
+		Texture::TransitionImageLayout(m_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, m_mipLevels, 6);
+		Texture::CreateImageSampler(true, false, m_mipLevels, m_sampler);
+		Texture::CreateImageView(m_image, VK_IMAGE_VIEW_TYPE_CUBE, m_format, m_mipLevels, m_imageView, 6);
+
+		Buffer::CopyBuffer(bufferStaging->GetVkBuffer(), m_buffer, m_size);
+
+		m_imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		m_imageInfo.imageView = m_imageView;
+		m_imageInfo.sampler = m_sampler;
+
+		delete bufferStaging;
+		delete[] pixels;
+
+#if FL_VERBOSE
+		const auto debugEnd = Engine::Get()->GetTimeMs();
+		printf("Cubemap '%s' loaded in %fms\n", m_filename.c_str(), debugEnd - debugStart);
+#endif
+	}
+
 	Cubemap::~Cubemap()
 	{
 		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();

--- a/Sources/Textures/Cubemap.cpp
+++ b/Sources/Textures/Cubemap.cpp
@@ -23,10 +23,10 @@ namespace fl
 		m_imageInfo({})
 	{
 #if FL_VERBOSE
-		const auto debugStart = Engine::Get()->GetTimeMs();
+		float debugStart = Engine::Get()->GetTimeMs();
 #endif
 
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		auto pixels = Texture::LoadPixels(filename, fileExt, SIDE_FILE_SUFFIXES, m_size, &m_width, &m_height, &m_depth, &m_components);
 
@@ -59,7 +59,7 @@ namespace fl
 		Texture::DeletePixels(pixels);
 
 #if FL_VERBOSE
-		const auto debugEnd = Engine::Get()->GetTimeMs();
+		float debugEnd = Engine::Get()->GetTimeMs();
 		printf("Cubemap '%s' loaded in %fms\n", m_filename.c_str(), debugEnd - debugStart);
 #endif
 	}
@@ -81,10 +81,10 @@ namespace fl
 		m_imageInfo({})
 	{
 #if FL_VERBOSE
-		const auto debugStart = Engine::Get()->GetTimeMs();
+		float debugStart = Engine::Get()->GetTimeMs();
 #endif
 
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		Buffer *bufferStaging = new Buffer(m_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
 			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
@@ -123,14 +123,14 @@ namespace fl
 		delete[] pixels;
 
 #if FL_VERBOSE
-		const auto debugEnd = Engine::Get()->GetTimeMs();
+		float debugEnd = Engine::Get()->GetTimeMs();
 		printf("Cubemap '%s' loaded in %fms\n", m_filename.c_str(), debugEnd - debugStart);
 #endif
 	}
 
 	Cubemap::~Cubemap()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		vkDestroySampler(logicalDevice, m_sampler, nullptr);
 		vkDestroyImage(logicalDevice, m_image, nullptr);

--- a/Sources/Textures/Cubemap.hpp
+++ b/Sources/Textures/Cubemap.hpp
@@ -48,8 +48,13 @@ namespace fl
 		Cubemap(const std::string &filename, const std::string &fileExt, const bool &mipmap = true);
 
 		/// <summary>
+		/// A new cubemap object from a array of pixels.
+		/// </summary>
+		Cubemap(const uint32_t &width, const uint32_t &height, const VkFormat &format, const VkImageLayout &imageLayout, const VkImageUsageFlags &usage, float *pixels = nullptr);
+
+		/// <summary>
 		/// Deconstructor for the cubemap object.
-		//		/// </summary>
+		/// </summary>
 		~Cubemap();
 
 		static DescriptorType CreateDescriptor(const uint32_t &binding, const VkShaderStageFlags &stage);

--- a/Sources/Textures/Cubemap.hpp
+++ b/Sources/Textures/Cubemap.hpp
@@ -28,17 +28,17 @@ namespace fl
 
 		VkDescriptorImageInfo m_imageInfo;
 	public:
-		static Cubemap *Resource(const std::string &filename, const std::string &fileExt)
+		static std::shared_ptr<Cubemap> Resource(const std::string &filename, const std::string &fileExt)
 		{
-			IResource *resource = Resources::Get()->Get(filename);
+			auto resource = Resources::Get()->Get(filename);
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<Cubemap *>(resource);
+				return std::dynamic_pointer_cast<Cubemap>(resource);
 			}
 
-			Cubemap *result = new Cubemap(filename, fileExt);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<Cubemap>(filename, fileExt);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 

--- a/Sources/Textures/Texture.cpp
+++ b/Sources/Textures/Texture.cpp
@@ -233,7 +233,7 @@ namespace fl
 
 		if (data == nullptr)
 		{
-			printf("Unable to load texture: '%s'\n", filepath.c_str());
+			fprintf(stderr, "Unable to load texture: '%s'\n", filepath.c_str());
 		}
 
 		return data;

--- a/Sources/Textures/Texture.cpp
+++ b/Sources/Textures/Texture.cpp
@@ -31,7 +31,7 @@ namespace fl
 		m_imageInfo({})
 	{
 #if FL_VERBOSE
-		const auto debugStart = Engine::Get()->GetTimeMs();
+		float debugStart = Engine::Get()->GetTimeMs();
 #endif
 
 		if (!FileSystem::FileExists(filename))
@@ -40,7 +40,7 @@ namespace fl
 			m_filename = FALLBACK_PATH;
 		}
 
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		auto pixels = LoadPixels(m_filename, &m_width, &m_height, &m_components);
 
@@ -74,7 +74,7 @@ namespace fl
 		m_filename = filename;
 
 #if FL_VERBOSE
-		const auto debugEnd = Engine::Get()->GetTimeMs();
+		float debugEnd = Engine::Get()->GetTimeMs();
 		printf("Texture '%s' loaded in %fms\n", m_filename.c_str(), debugEnd - debugStart);
 #endif
 	}
@@ -99,7 +99,7 @@ namespace fl
 		m_format(format),
 		m_imageInfo({})
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		Buffer *bufferStaging = new Buffer(m_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
 			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
@@ -139,7 +139,7 @@ namespace fl
 
 	Texture::~Texture()
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		vkDestroySampler(logicalDevice, m_sampler, nullptr);
 		vkDestroyImageView(logicalDevice, m_imageView, nullptr);
@@ -206,7 +206,7 @@ namespace fl
 	{
 		VkDeviceSize size = 0;
 
-		for (const auto suffix : fileSuffixes)
+		for (auto suffix : fileSuffixes)
 		{
 			const std::string filepathSide = filename + "/" + suffix + fileExt;
 			const VkDeviceSize sizeSide = LoadSize(filepathSide);
@@ -247,7 +247,7 @@ namespace fl
 		stbi_uc *pixels = (stbi_uc *) malloc(bufferSize);
 		stbi_uc *offset = pixels;
 
-		for (const auto suffix : fileSuffixes)
+		for (auto suffix : fileSuffixes)
 		{
 			std::string filepathSide = filename + "/" + suffix + fileExt;
 			VkDeviceSize sizeSide = LoadSize(filepathSide);
@@ -274,7 +274,7 @@ namespace fl
 
 	void Texture::CreateImage(const int32_t &width, const int32_t &height, const int32_t &depth, const uint32_t &mipLevels, const VkFormat &format, const VkImageTiling &tiling, const VkImageUsageFlags &usage, const VkMemoryPropertyFlags &properties, VkImage &image, VkDeviceMemory &imageMemory, const uint32_t &arrayLayers)
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		VkImageCreateInfo imageCreateInfo = {};
 		imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -450,7 +450,7 @@ namespace fl
 
 	void Texture::CreateImageSampler(const bool &anisotropic, const bool &nearest, const uint32_t &mipLevels, VkSampler &sampler)
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		VkSamplerCreateInfo samplerCreateInfo = {};
 		samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
@@ -475,7 +475,7 @@ namespace fl
 
 	void Texture::CreateImageView(const VkImage &image, const VkImageViewType &type, const VkFormat &format, const uint32_t &mipLevels, VkImageView &imageView, const uint32_t &layerCount)
 	{
-		const auto logicalDevice = Display::Get()->GetVkLogicalDevice();
+		auto logicalDevice = Display::Get()->GetVkLogicalDevice();
 
 		VkImageViewCreateInfo imageViewCreateInfo = {};
 		imageViewCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;

--- a/Sources/Textures/Texture.cpp
+++ b/Sources/Textures/Texture.cpp
@@ -82,6 +82,8 @@ namespace fl
 	Texture::Texture(const uint32_t &width, const uint32_t &height, const VkFormat &format, const VkImageLayout &imageLayout, const VkImageUsageFlags &usage, float *pixels) :
 		IResource(),
 		Buffer(width * height * 4, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT),
+		IDescriptor(),
+		m_filename(""),
 		m_hasAlpha(false),
 		m_repeatEdges(false),
 		m_mipLevels(1),

--- a/Sources/Textures/Texture.hpp
+++ b/Sources/Textures/Texture.hpp
@@ -59,7 +59,7 @@ namespace fl
 				const bool &anisotropic = true, const bool &nearest = false, const uint32_t &numberOfRows = 1);
 
 		/// <summary>
-		/// A new empty texture object.
+		/// A new texture object from a array of pixels.
 		/// </summary>
 		Texture(const uint32_t &width, const uint32_t &height, const VkFormat &format, const VkImageLayout &imageLayout, const VkImageUsageFlags &usage, float *pixels = nullptr);
 

--- a/Sources/Textures/Texture.hpp
+++ b/Sources/Textures/Texture.hpp
@@ -38,17 +38,17 @@ namespace fl
 
 		VkDescriptorImageInfo m_imageInfo;
 	public:
-		static Texture *Resource(const std::string &filename)
+		static std::shared_ptr<Texture> Resource(const std::string &filename)
 		{
-			IResource *resource = Resources::Get()->Get(filename);
+			auto resource = Resources::Get()->Get(filename);
 
 			if (resource != nullptr)
 			{
-				return dynamic_cast<Texture *>(resource);
+				return std::dynamic_pointer_cast<Texture>(resource);
 			}
 
-			Texture *result = new Texture(filename);
-			Resources::Get()->Add(dynamic_cast<IResource *>(result));
+			auto result = std::make_shared<Texture>(filename);
+			Resources::Get()->Add(std::dynamic_pointer_cast<IResource>(result));
 			return result;
 		}
 

--- a/Sources/Uis/UiBound.cpp
+++ b/Sources/Uis/UiBound.cpp
@@ -61,7 +61,7 @@ namespace fl
 
 	Vector2 UiBound::FindPivot(const std::string &key)
 	{
-		const auto it = PIVOT_MAP.find(key);
+		auto it = PIVOT_MAP.find(key);
 
 		if (it == PIVOT_MAP.end())
 		{

--- a/Sources/Uis/UiBound.cpp
+++ b/Sources/Uis/UiBound.cpp
@@ -59,7 +59,7 @@ namespace fl
 		if (it == PIVOT_MAP.end())
 		{
 #if FL_VERBOSE
-			printf("Could not find a UiBound pivot from key: %s", key.c_str());
+			fprintf(stderr, "Could not find a UiBound pivot from key: %s", key.c_str());
 #endif
 			return Vector2(0.0f, 1.0f);
 		}

--- a/Sources/Uis/UiBound.cpp
+++ b/Sources/Uis/UiBound.cpp
@@ -18,38 +18,45 @@ namespace fl
 		};
 
 	UiBound::UiBound(const Vector2 &position, const std::string &reference, const bool &aspectPosition, const bool &aspectSize, const Vector2 &dimensions) :
-		m_position(new Vector2(position)),
-		m_reference(new Vector2(FindPivot(reference))),
+		m_position(Vector2(position)),
+		m_reference(Vector2(FindPivot(reference))),
 		m_aspectPosition(aspectPosition),
 		m_aspectSize(aspectSize),
-		m_dimensions(new Vector2(dimensions))
+		m_dimensions(Vector2(dimensions))
 	{
 	}
 
 	UiBound::UiBound(const UiBound &source) :
-		m_position(new Vector2(*source.m_position)),
-		m_reference(new Vector2(*source.m_reference)),
+		m_position(Vector2(source.m_position)),
+		m_reference(Vector2(source.m_reference)),
 		m_aspectPosition(source.m_aspectPosition),
 		m_aspectSize(source.m_aspectSize),
-		m_dimensions(new Vector2(*source.m_dimensions))
+		m_dimensions(Vector2(source.m_dimensions))
 	{
 	}
 
 	UiBound::~UiBound()
 	{
-		delete m_position;
-		delete m_dimensions;
-		delete m_reference;
 	}
 
-	UiBound *UiBound::Set(const UiBound &source)
+	UiBound &UiBound::operator=(const UiBound &other)
 	{
-		*m_position = *source.m_position;
-		*m_reference = *source.m_reference;
-		m_aspectPosition = source.m_aspectPosition;
-		m_aspectSize = source.m_aspectSize;
-		*m_dimensions = *source.m_dimensions;
-		return this;
+		m_position = other.m_position;
+		m_reference = other.m_reference;
+		m_aspectPosition = other.m_aspectPosition;
+		m_aspectSize = other.m_aspectSize;
+		m_dimensions = other.m_dimensions;
+		return *this;
+	}
+
+	bool UiBound::operator==(const UiBound &other) const
+	{
+		return m_position == other.m_position && m_reference == other.m_reference && m_aspectPosition == other.m_aspectPosition && m_aspectSize == other.m_aspectSize && m_dimensions == other.m_dimensions;
+	}
+
+	bool UiBound::operator!=(const UiBound &other) const
+	{
+		return !(*this == other);
 	}
 
 	Vector2 UiBound::FindPivot(const std::string &key)

--- a/Sources/Uis/UiBound.hpp
+++ b/Sources/Uis/UiBound.hpp
@@ -13,11 +13,11 @@ namespace fl
 	private:
 		static std::map<std::string, Vector2> PIVOT_MAP;
 	public:
-		Vector2 *m_position;
-		Vector2 *m_reference;
+		Vector2 m_position;
+		Vector2 m_reference;
 		bool m_aspectPosition;
 		bool m_aspectSize;
-		Vector2 *m_dimensions;
+		Vector2 m_dimensions;
 
 		/// <summary>
 		/// Constructor for rectangle.
@@ -40,20 +40,13 @@ namespace fl
 		/// </summary>
 		~UiBound();
 
-		/// <summary>
-		/// Loads from another Rectangle.
-		/// </summary>
-		/// <param name="source"> The source rectangle. </param>
-		/// <returns> This. </returns>
-		UiBound *Set(const UiBound &source);
+		Vector2 GetPosition() const { return m_position; }
 
-		Vector2 *GetPosition() const { return m_position; }
+		void SetPosition(const Vector2 &position) { m_position = position; }
 
-		void SetPosition(const Vector2 &position) { *m_position = position; }
+		Vector2 GetReference() const { return m_reference; }
 
-		Vector2 *GetReference() const { return m_reference; }
-
-		void SetReference(Vector2 *reference) { m_reference = reference; }
+		void SetReference(const Vector2 &reference) { m_reference = reference; }
 
 		bool IsAspectPosition() const { return m_aspectPosition; }
 
@@ -63,9 +56,15 @@ namespace fl
 
 		void SetAspectSize(const bool &aspectSize) { m_aspectSize = aspectSize; }
 
-		Vector2 *GetDimensions() const { return m_dimensions; }
+		Vector2 GetDimensions() const { return m_dimensions; }
 
-		void SetDimensions(const Vector2 &dimensions) { *m_dimensions = dimensions; }
+		void SetDimensions(const Vector2 &dimensions) { m_dimensions = dimensions; }
+
+		UiBound &operator=(const UiBound &other);
+
+		bool operator==(const UiBound &other) const;
+
+		bool operator!=(const UiBound &other) const;
 
 		static Vector2 FindPivot(const std::string &key);
 	};

--- a/Sources/Uis/UiInputButton.cpp
+++ b/Sources/Uis/UiInputButton.cpp
@@ -8,7 +8,7 @@ namespace fl
 	const float UiInputButton::CHANGE_TIME = 0.1f;
 	const float UiInputButton::SCALE_NORMAL = 1.6f;
 	const float UiInputButton::SCALE_SELECTED = 1.8f;
-	const Colour *UiInputButton::COLOUR_NORMAL = new Colour("#000000");
+	const Colour UiInputButton::COLOUR_NORMAL = Colour("#000000");
 
 	UiInputButton::UiInputButton(UiObject *parent, const Vector2 &position, const std::string &string, const FontJustify &justify) :
 		UiObject(parent, UiBound(Vector2(0.5f, 0.5f), "Centre", true, true, Vector2(1.0f, 1.0f))),
@@ -40,7 +40,7 @@ namespace fl
 
 		// Update the background colour.
 		Colour *primary = Scenes::Get()->GetUiManager()->GetPrimaryColour();
-		m_background->SetColourOffset(COLOUR_NORMAL->Interpolate(*primary, (m_text->GetScale() - SCALE_NORMAL) / (SCALE_SELECTED - SCALE_NORMAL)));
+		m_background->SetColourOffset(COLOUR_NORMAL.Interpolate(*primary, (m_text->GetScale() - SCALE_NORMAL) / (SCALE_SELECTED - SCALE_NORMAL)));
 
 		// Update background size.
 		//m_background->GetRectangle()->m_dimensions->Set(*m_text->GetRectangle()->m_dimensions);

--- a/Sources/Uis/UiInputButton.hpp
+++ b/Sources/Uis/UiInputButton.hpp
@@ -14,7 +14,7 @@ namespace fl
 		static const float CHANGE_TIME;
 		static const float SCALE_NORMAL;
 		static const float SCALE_SELECTED;
-		static const Colour *COLOUR_NORMAL;
+		static const Colour COLOUR_NORMAL;
 
 		Text *m_text;
 		Gui *m_background;

--- a/Sources/Uis/UiInputGrabber.cpp
+++ b/Sources/Uis/UiInputGrabber.cpp
@@ -9,7 +9,7 @@ namespace fl
 	const float UiInputGrabber::CHANGE_TIME = 0.1f;
 	const float UiInputGrabber::SCALE_NORMAL = 1.6f;
 	const float UiInputGrabber::SCALE_SELECTED = 1.8f;
-	const Colour *UiInputGrabber::COLOUR_NORMAL = new Colour("#000000");
+	const Colour UiInputGrabber::COLOUR_NORMAL = Colour("#000000");
 
 	UiGrabberJoystick::UiGrabberJoystick(const JoystickPort &joystick) :
 		IUiGrabber(),
@@ -173,7 +173,7 @@ namespace fl
 
 		// Update the background colour.
 		Colour *primary = Scenes::Get()->GetUiManager()->GetPrimaryColour();
-		m_background->SetColourOffset(COLOUR_NORMAL->Interpolate(*primary, (m_text->GetScale() - SCALE_NORMAL) / (SCALE_SELECTED - SCALE_NORMAL)));
+		m_background->SetColourOffset(COLOUR_NORMAL.Interpolate(*primary, (m_text->GetScale() - SCALE_NORMAL) / (SCALE_SELECTED - SCALE_NORMAL)));
 
 		// Update background size.
 		//m_background->GetDimensions()->Set(*m_text->GetDimensions());

--- a/Sources/Uis/UiInputGrabber.hpp
+++ b/Sources/Uis/UiInputGrabber.hpp
@@ -56,7 +56,7 @@ namespace fl
 		static const float CHANGE_TIME;
 		static const float SCALE_NORMAL;
 		static const float SCALE_SELECTED;
-		static const Colour *COLOUR_NORMAL;
+		static const Colour COLOUR_NORMAL;
 
 		Text *m_text;
 		Gui *m_background;

--- a/Sources/Uis/UiInputSlider.cpp
+++ b/Sources/Uis/UiInputSlider.cpp
@@ -8,7 +8,7 @@ namespace fl
 	const float UiInputSlider::CHANGE_TIME = 0.1f;
 	const float UiInputSlider::SCALE_NORMAL = 1.6f;
 	const float UiInputSlider::SCALE_SELECTED = 1.8f;
-	const Colour *UiInputSlider::COLOUR_NORMAL = new Colour("#000000");
+	const Colour UiInputSlider::COLOUR_NORMAL = Colour("#000000");
 
 	UiInputSlider::UiInputSlider(UiObject *parent, const Vector3 &position, const std::string &string, const float &progressMin, const float &progressMax, const float &value, const FontJustify &justify) :
 		UiObject(parent, UiBound(position, "Centre", true, true, Vector2(1.0f, 1.0f))),
@@ -87,7 +87,7 @@ namespace fl
 
 		// Update the background colour.
 		Colour *primary = Scenes::Get()->GetUiManager()->GetPrimaryColour();
-		m_background->SetColourOffset(COLOUR_NORMAL->Interpolate(*primary, (m_text->GetScale() - SCALE_NORMAL) / (SCALE_SELECTED - SCALE_NORMAL)));
+		m_background->SetColourOffset(COLOUR_NORMAL.Interpolate(*primary, (m_text->GetScale() - SCALE_NORMAL) / (SCALE_SELECTED - SCALE_NORMAL)));
 		m_slider->SetColourOffset(Colour(1.0f - primary->m_r, 1.0f - primary->m_g, 1.0f - primary->m_b, 1.0f));
 
 		//	// Update background size.

--- a/Sources/Uis/UiInputSlider.hpp
+++ b/Sources/Uis/UiInputSlider.hpp
@@ -16,7 +16,7 @@ namespace fl
 		static const float CHANGE_TIME;
 		static const float SCALE_NORMAL;
 		static const float SCALE_SELECTED;
-		static const Colour *COLOUR_NORMAL;
+		static const Colour COLOUR_NORMAL;
 
 		Text *m_text;
 		Gui *m_background;

--- a/Sources/Uis/UiInputText.cpp
+++ b/Sources/Uis/UiInputText.cpp
@@ -9,7 +9,7 @@ namespace fl
 	const float UiInputText::CHANGE_TIME = 0.1f;
 	const float UiInputText::SCALE_NORMAL = 1.6f;
 	const float UiInputText::SCALE_SELECTED = 1.8f;
-	const Colour *UiInputText::COLOUR_NORMAL = new Colour("#000000");
+	const Colour UiInputText::COLOUR_NORMAL = Colour("#000000");
 
 	UiInputText::UiInputText(UiObject *parent, const Vector3 &position, const std::string &prefix, const std::string &value, const FontJustify &justify) :
 		UiObject(parent, UiBound(Vector2(0.5f, 0.5f), "Centre", true, true, Vector2(1.0f, 1.0f))),
@@ -118,7 +118,7 @@ namespace fl
 
 		// Update the background colour.
 		Colour *primary = Scenes::Get()->GetUiManager()->GetPrimaryColour();
-		m_background->SetColourOffset(COLOUR_NORMAL->Interpolate(*primary, (m_text->GetScale() - SCALE_NORMAL) / (SCALE_SELECTED - SCALE_NORMAL)));
+		m_background->SetColourOffset(COLOUR_NORMAL.Interpolate(*primary, (m_text->GetScale() - SCALE_NORMAL) / (SCALE_SELECTED - SCALE_NORMAL)));
 
 		// Update background size.
 		//*m_background->GetDimensions() = *m_text->GetDimensions();

--- a/Sources/Uis/UiInputText.hpp
+++ b/Sources/Uis/UiInputText.hpp
@@ -15,7 +15,7 @@ namespace fl
 		static const float CHANGE_TIME;
 		static const float SCALE_NORMAL;
 		static const float SCALE_SELECTED;
-		static const Colour *COLOUR_NORMAL;
+		static const Colour COLOUR_NORMAL;
 
 		Text *m_text;
 		Gui *m_background;

--- a/Sources/Uis/UiObject.cpp
+++ b/Sources/Uis/UiObject.cpp
@@ -23,7 +23,7 @@ namespace fl
 	{
 		if (parent != nullptr)
 		{
-			parent->m_children->push_back(this);
+			parent->m_children->emplace_back(this);
 		}
 	}
 
@@ -117,7 +117,7 @@ namespace fl
 	{
 		if (IsVisible())
 		{
-			list->push_back(this);
+			list->emplace_back(this);
 
 			for (auto child : *m_children)
 			{
@@ -131,7 +131,7 @@ namespace fl
 	void UiObject::SetParent(UiObject *parent)
 	{
 		m_parent->RemoveChild(this);
-		parent->m_children->push_back(this);
+		parent->m_children->emplace_back(this);
 		m_parent = parent;
 	}
 

--- a/Sources/Uis/UiObject.cpp
+++ b/Sources/Uis/UiObject.cpp
@@ -86,12 +86,12 @@ namespace fl
 		float aspectRatio = Display::Get()->GetAspectRatio();
 
 		float da = m_rectangle->m_aspectSize ? aspectRatio : 1.0f;
-		float dw = (m_rectangle->m_dimensions->m_x / da) * m_scale;
-		float dh = m_rectangle->m_dimensions->m_y * m_scale;
+		float dw = (m_rectangle->GetDimensions().m_x / da) * m_scale;
+		float dh = m_rectangle->GetDimensions().m_y * m_scale;
 
 		float pa = m_rectangle->m_aspectPosition ? 1.0f : aspectRatio;
-		float px = (m_rectangle->m_position->m_x / pa) - (dw * m_rectangle->m_reference->m_x) + m_positionOffset->m_x;
-		float py = m_rectangle->m_position->m_y - (dh * (-1.0f + m_rectangle->m_reference->m_y)) + m_positionOffset->m_y;
+		float px = (m_rectangle->GetPosition().m_x / pa) - (dw * m_rectangle->GetReference().m_x) + m_positionOffset->m_x;
+		float py = m_rectangle->GetPosition().m_y - (dh * (-1.0f + m_rectangle->GetReference().m_y)) + m_positionOffset->m_y;
 
 		*m_screenTransform = Vector4(2.0f * dw, 2.0f * dh, (2.0f * px) - 1.0f, (-2.0f * py) + 1.0f);
 	}

--- a/Sources/Uis/UiObject.hpp
+++ b/Sources/Uis/UiObject.hpp
@@ -93,7 +93,7 @@ namespace fl
 
 		UiBound *GetRectangle() const { return m_rectangle; }
 
-		void SetRectangle(const UiBound &rectangle) const { m_rectangle->Set(rectangle); }
+		void SetRectangle(const UiBound &rectangle) { *m_rectangle = rectangle; }
 
 		Vector4 *GetScissor() const { return m_scissor; }
 

--- a/Sources/Uis/UiSelector.cpp
+++ b/Sources/Uis/UiSelector.cpp
@@ -10,8 +10,7 @@ namespace fl
 		m_leftWasClick(false),
 		m_rightWasClick(false),
 		m_mouseLeft(new ButtonMouse({MouseButton::MOUSE_BUTTON_LEFT})),
-		m_mouseRight(new ButtonMouse({MouseButton::MOUSE_BUTTON_RIGHT})),
-		m_selectorJoystick(nullptr)
+		m_mouseRight(new ButtonMouse({MouseButton::MOUSE_BUTTON_RIGHT}))
 	{
 	}
 
@@ -19,22 +18,9 @@ namespace fl
 	{
 		delete m_mouseLeft;
 		delete m_mouseRight;
-
-		delete m_selectorJoystick;
 	}
 
-	void UiSelector::Load(const JoystickPort &joystick, const int &joystickLeftClick, const int &joystickRightClick, const int &joystickAxisX, const int &joystickAxisY)
-	{
-		m_selectorJoystick = new SelectorJoystick{
-			joystick,
-			new ButtonJoystick(joystick, {joystickLeftClick}),
-			new ButtonJoystick(joystick, {joystickRightClick}),
-			new AxisJoystick(joystick, {joystickAxisX}),
-			new AxisJoystick(joystick, {joystickAxisY})
-		};
-	}
-
-	void UiSelector::Update(const bool &paused)
+	void UiSelector::Update(const bool &paused, const SelectorJoystick &selectorJoystick)
 	{
 		float delta = Engine::Get()->GetDelta();
 
@@ -46,22 +32,22 @@ namespace fl
 		m_cursorX = Mouse::Get()->GetPositionX();
 		m_cursorY = Mouse::Get()->GetPositionY();
 
-		if (m_selectorJoystick != nullptr && Joysticks::Get()->IsConnected(m_selectorJoystick->joystick) && paused)
+		if (Joysticks::Get()->IsConnected(selectorJoystick.GetJoystick()) && paused)
 		{
-			if (std::fabs(Maths::Deadband(0.1f, m_selectorJoystick->axisX->GetAmount())) > 0.0f ||
-				std::fabs(Maths::Deadband(0.1f, m_selectorJoystick->axisY->GetAmount())) > 0.0f)
+			if (std::fabs(Maths::Deadband(0.1f, selectorJoystick.GetAxisX()->GetAmount())) > 0.0f ||
+				std::fabs(Maths::Deadband(0.1f, selectorJoystick.GetAxisY()->GetAmount())) > 0.0f)
 			{
-				m_cursorX += m_selectorJoystick->axisX->GetAmount() * 0.75f * delta;
-				m_cursorY += m_selectorJoystick->axisY->GetAmount() * 0.75f * delta;
+				m_cursorX += selectorJoystick.GetAxisX()->GetAmount() * 0.75f * delta;
+				m_cursorY += selectorJoystick.GetAxisY()->GetAmount() * 0.75f * delta;
 				m_cursorX = Maths::Clamp(m_cursorX, 0.0f, 1.0f);
 				m_cursorY = Maths::Clamp(m_cursorY, 0.0f, 1.0f);
 				Mouse::Get()->SetPosition(m_cursorX, m_cursorY);
 			}
 
-			m_leftClick = m_leftClick || m_selectorJoystick->clickLeft->IsDown();
-			m_rightClick = m_rightClick || m_selectorJoystick->clickRight->IsDown();
-			m_leftWasClick = m_leftWasClick || m_selectorJoystick->clickLeft->WasDown();
-			m_rightWasClick = m_rightWasClick || m_selectorJoystick->clickRight->WasDown();
+			m_leftClick = m_leftClick || selectorJoystick.GetClickLeft()->IsDown();
+			m_rightClick = m_rightClick || selectorJoystick.GetClickRight()->IsDown();
+			m_leftWasClick = m_leftWasClick || selectorJoystick.GetClickLeft()->WasDown();
+			m_rightWasClick = m_rightWasClick || selectorJoystick.GetClickRight()->WasDown();
 		}
 	}
 

--- a/Sources/Uis/UiSelector.hpp
+++ b/Sources/Uis/UiSelector.hpp
@@ -7,14 +7,51 @@
 
 namespace fl
 {
-	struct FL_HIDDEN SelectorJoystick
+	struct FL_EXPORT SelectorJoystick
 	{
+	private:
+		JoystickPort m_joystick;
+		ButtonJoystick *m_clickLeft;
+		ButtonJoystick *m_clickRight;
+		AxisJoystick *m_axisX;
+		AxisJoystick *m_axisY;
 	public:
-		JoystickPort joystick;
-		ButtonJoystick *clickLeft;
-		ButtonJoystick *clickRight;
-		AxisJoystick *axisX;
-		AxisJoystick *axisY;
+		SelectorJoystick(const JoystickPort &joystick = JOYSTICK_LAST, const int &joystickLeftClick = 0, const int &joystickRightClick = 1, const int &joystickAxisX = 0, const int &joystickAxisY = 1) :
+			m_joystick(joystick),
+			m_clickLeft(new ButtonJoystick(joystick, {joystickLeftClick})),
+			m_clickRight(new ButtonJoystick(joystick, {joystickRightClick})),
+			m_axisX(new AxisJoystick(joystick, {joystickAxisX})),
+			m_axisY(new AxisJoystick(joystick, {joystickAxisY}))
+		{
+		}
+
+		~SelectorJoystick()
+		{
+			delete m_clickLeft;
+			delete m_clickRight;
+			delete m_axisX;
+			delete m_axisY;
+		}
+
+		JoystickPort GetJoystick() const { return m_joystick; }
+
+		void SetJoystick(const JoystickPort &joystick) { m_joystick = joystick; }
+
+		ButtonJoystick *GetClickLeft() const { return m_clickLeft; }
+
+	//	void SetClickLeft(const ButtonJoystick &clickLeft) { m_clickLeft = clickLeft; }
+
+		ButtonJoystick *GetClickRight() const { return m_clickRight; }
+
+	//	void SetClickRight(const ButtonJoystick &clickRight) { m_clickRight = clickRight; }
+
+		AxisJoystick *GetAxisX() const { return m_axisX; }
+
+	//	void SetAxisX(const AxisJoystick &axisX) { m_axisX = axisX; }
+
+		AxisJoystick *GetAxisY() const { return m_axisY; }
+
+	//	void SetAxisY(const AxisJoystick &axisY) { m_axisY = axisY; }
 	};
 
 	/// <summary>
@@ -33,24 +70,12 @@ namespace fl
 
 		ButtonMouse *m_mouseLeft;
 		ButtonMouse *m_mouseRight;
-
-		SelectorJoystick *m_selectorJoystick;
 	public:
 		UiSelector();
 
 		~UiSelector();
 
-		/// <summary>
-		/// Sets up the joystick settings to be used for controlling the virtual cursor.
-		/// </summary>
-		/// <param name="joystick"> The joystick port to attach to. </param>
-		/// <param name="joystickLeftClick"> The joystick key to be used as the left click. </param>
-		/// <param name="joystickRightClick"> The joystick key to be used as the right click. </param>
-		/// <param name="joystickAxisX"> The joystick axis to be used for moving the x axis. </param>
-		/// <param name="joystickAxisY"> The joystick axis to be used for moving the y axis. </param>
-		void Load(const JoystickPort &joystick, const int &joystickLeftClick, const int &joystickRightClick, const int &joystickAxisX, const int &joystickAxisY);
-
-		void Update(const bool &paused);
+		void Update(const bool &paused, const SelectorJoystick &selectorJoystick);
 
 		/// <summary>
 		/// Gets if the object provided has the cursor hovered above it.

--- a/Sources/Uis/UiStartLogo.cpp
+++ b/Sources/Uis/UiStartLogo.cpp
@@ -33,7 +33,7 @@ namespace fl
 
 	void UiStartLogo::UpdateObject()
 	{
-		m_guiBackground->GetRectangle()->m_dimensions->m_x = Display::Get()->GetAspectRatio();
+		m_guiBackground->GetRectangle()->m_dimensions.m_x = Display::Get()->GetAspectRatio();
 		m_guiBackground->SetScaleDriver(new DriverConstant(1.6f));
 		m_guiBackground->SetVisible(true);
 		m_guiLogo->SetVisible(true);

--- a/Sources/Uis/Uis.cpp
+++ b/Sources/Uis/Uis.cpp
@@ -18,8 +18,6 @@ namespace fl
 		delete m_selector;
 		delete m_container;
 		delete m_objects;
-
-		delete m_proximaNova;
 	}
 
 	void Uis::Update()

--- a/Sources/Uis/Uis.cpp
+++ b/Sources/Uis/Uis.cpp
@@ -8,7 +8,7 @@ namespace fl
 		IModule(),
 		m_selector(new UiSelector()),
 		m_container(new UiObject(nullptr, UiBound(Vector2(0.5f, 0.5f), "Centre", true, true, Vector2(1.0f, 1.0f)))),
-		m_objects(new std::vector<UiObject *>()),
+		m_objects(std::vector<UiObject *>()),
 		m_proximaNova(FontFamily::Resource("Resources/Fonts/ProximaNova"))
 	{
 	}
@@ -17,12 +17,11 @@ namespace fl
 	{
 		delete m_selector;
 		delete m_container;
-		delete m_objects;
 	}
 
 	void Uis::Update()
 	{
-		m_objects->clear();
+		m_objects.clear();
 
 		if (Scenes::Get()->GetUiManager() != nullptr && Scenes::Get()->GetUiManager()->GetSelectorJoystick() != nullptr)
 		{
@@ -30,6 +29,6 @@ namespace fl
 		}
 
 		m_container->Update();
-		m_container->GetAll(m_objects);
+		m_container->GetAll(&m_objects);
 	}
 }

--- a/Sources/Uis/Uis.cpp
+++ b/Sources/Uis/Uis.cpp
@@ -24,7 +24,11 @@ namespace fl
 	{
 		m_objects->clear();
 
-		m_selector->Update(Scenes::Get()->IsGamePaused());
+		if (Scenes::Get()->GetUiManager() != nullptr && Scenes::Get()->GetUiManager()->GetSelectorJoystick() != nullptr)
+		{
+			m_selector->Update(Scenes::Get()->IsGamePaused(), *Scenes::Get()->GetUiManager()->GetSelectorJoystick());
+		}
+
 		m_container->Update();
 		m_container->GetAll(m_objects);
 	}

--- a/Sources/Uis/Uis.hpp
+++ b/Sources/Uis/Uis.hpp
@@ -17,7 +17,7 @@ namespace fl
 		UiObject *m_container;
 		std::vector<UiObject *> *m_objects;
 	public:
-		FontFamily *m_proximaNova;
+		std::shared_ptr<FontFamily> m_proximaNova;
 
 		/// <summary>
 		/// Gets this engine instance.

--- a/Sources/Uis/Uis.hpp
+++ b/Sources/Uis/Uis.hpp
@@ -15,7 +15,7 @@ namespace fl
 	private:
 		UiSelector *m_selector;
 		UiObject *m_container;
-		std::vector<UiObject *> *m_objects;
+		std::vector<UiObject *> m_objects;
 	public:
 		std::shared_ptr<FontFamily> m_proximaNova;
 
@@ -56,6 +56,6 @@ namespace fl
 		/// The rendering objects from the container. Updated each update.
 		/// </summary>
 		/// <returns> The objects. </returns>
-		std::vector<UiObject *> *GetObjects() const { return m_objects; };
+		std::vector<UiObject *> GetObjects() const { return m_objects; };
 	};
 }

--- a/Sources/Worlds/Worlds.cpp
+++ b/Sources/Worlds/Worlds.cpp
@@ -28,7 +28,7 @@ namespace fl
 		m_moonPosition(new Vector3()),
 		m_sunColour(new Colour()),
 		m_moonColour(new Colour()),
-		m_fog(new Fog(new Colour(), 0.001f, 2.0f, -0.1f, 0.3f)),
+		m_fog(new Fog(Colour::WHITE, 0.001f, 2.0f, -0.1f, 0.3f)),
 		m_skyColour(new Colour("#3399ff"))
 	{
 		m_noiseTerrain->SetNoiseType(NoiseType::TYPE_PERLINFRACTAL);

--- a/Sources/Worlds/Worlds.cpp
+++ b/Sources/Worlds/Worlds.cpp
@@ -76,8 +76,8 @@ namespace fl
 
 		/*if (Scenes::Get()->GetCamera() != nullptr)
 		{
-			Vector3::Add(*m_sunPosition, *Scenes::Get()->GetCamera()->GetPosition(), m_sunPosition);
-			Vector3::Add(*m_moonPosition, *Scenes::Get()->GetCamera()->GetPosition(), m_moonPosition);
+			Vector3::Add(*m_sunPosition, Scenes::Get()->GetCamera()->GetPosition(), m_sunPosition);
+			Vector3::Add(*m_moonPosition, Scenes::Get()->GetCamera()->GetPosition(), m_moonPosition);
 		}*/
 
 		*m_sunColour = SUN_COLOUR_SUNRISE.Interpolate(SUN_COLOUR_NIGHT, GetSunriseFactor());

--- a/Sources/Worlds/Worlds.cpp
+++ b/Sources/Worlds/Worlds.cpp
@@ -20,78 +20,66 @@ namespace fl
 
 	Worlds::Worlds() :
 		IModule(),
-		m_noiseTerrain(new Noise(69124)),
-		m_driverDay(new DriverLinear(0.0f, 1.0f, 300.0f)),
+		m_noiseTerrain(Noise(69124)),
+		m_driverDay(DriverLinear(0.0f, 1.0f, 300.0f)),
 		m_factorDay(0.0f),
-		m_skyboxRotation(new Vector3),
-		m_sunPosition(new Vector3()),
-		m_moonPosition(new Vector3()),
-		m_sunColour(new Colour()),
-		m_moonColour(new Colour()),
-		m_fog(new Fog(Colour::WHITE, 0.001f, 2.0f, -0.1f, 0.3f)),
-		m_skyColour(new Colour("#3399ff"))
+		m_skyboxRotation(Vector3()),
+		m_sunPosition(Vector3()),
+		m_moonPosition(Vector3()),
+		m_sunColour(Colour()),
+		m_moonColour(Colour()),
+		m_fog(Fog(Colour::WHITE, 0.001f, 2.0f, -0.1f, 0.3f)),
+		m_skyColour(Colour("#3399ff"))
 	{
-		m_noiseTerrain->SetNoiseType(NoiseType::TYPE_PERLINFRACTAL);
-		m_noiseTerrain->SetFrequency(0.003f);
-		m_noiseTerrain->SetInterp(NoiseInterp::INTERP_QUINTIC);
-		m_noiseTerrain->SetFractalType(NoiseFractal::FRACTAL_FBM);
-		m_noiseTerrain->SetFractalOctaves(5);
-		m_noiseTerrain->SetFractalLacunarity(2.0f);
-		m_noiseTerrain->SetFractalGain(0.5f);
+		m_noiseTerrain.SetNoiseType(NoiseType::TYPE_PERLINFRACTAL);
+		m_noiseTerrain.SetFrequency(0.003f);
+		m_noiseTerrain.SetInterp(NoiseInterp::INTERP_QUINTIC);
+		m_noiseTerrain.SetFractalType(NoiseFractal::FRACTAL_FBM);
+		m_noiseTerrain.SetFractalOctaves(5);
+		m_noiseTerrain.SetFractalLacunarity(2.0f);
+		m_noiseTerrain.SetFractalGain(0.5f);
 
-		m_driverDay->Update(50.0f); // Starts during daytime.
+		m_driverDay.Update(50.0f); // Starts during daytime.
 	}
 
 	Worlds::~Worlds()
 	{
-		delete m_noiseTerrain;
-
-		delete m_driverDay;
-
-		delete m_skyboxRotation;
-		delete m_sunPosition;
-		delete m_moonPosition;
-		delete m_sunColour;
-		delete m_moonColour;
-
-		delete m_fog;
-		delete m_skyColour;
 	}
 
 	void Worlds::Update()
 	{
 		float delta = Engine::Get()->GetDelta();
-		m_factorDay = m_driverDay->Update(delta);
+		m_factorDay = m_driverDay.Update(delta);
 
-		*m_skyboxRotation = Vector3(360.0f * m_factorDay, 0.0f, 0.0f);
+		m_skyboxRotation = Vector3(360.0f * m_factorDay, 0.0f, 0.0f);
 
-		Vector3 lightDirection = m_skyboxRotation->Rotate(Vector3(0.2f, 0.0f, 0.5f));
+		Vector3 lightDirection = m_skyboxRotation.Rotate(Vector3(0.2f, 0.0f, 0.5f));
 		lightDirection.Normalize();
 
 		Colour fogColour = FOG_COLOUR_SUNRISE.Interpolate(FOG_COLOUR_NIGHT, GetSunriseFactor());
 		fogColour = fogColour.Interpolate(FOG_COLOUR_DAY, GetShadowFactor());
 
-		*m_sunPosition = lightDirection * Vector3(-6048.0f, -6048.0f, -6048.0f);
-		*m_moonPosition = lightDirection * Vector3(6048.0f, 6048.0f, 6048.0f);
+		m_sunPosition = lightDirection * Vector3(-6048.0f, -6048.0f, -6048.0f);
+		m_moonPosition = lightDirection * Vector3(6048.0f, 6048.0f, 6048.0f);
 
 		/*if (Scenes::Get()->GetCamera() != nullptr)
 		{
-			Vector3::Add(*m_sunPosition, Scenes::Get()->GetCamera()->GetPosition(), m_sunPosition);
-			Vector3::Add(*m_moonPosition, Scenes::Get()->GetCamera()->GetPosition(), m_moonPosition);
+			m_sunPosition += Scenes::Get()->GetCamera()->GetPosition();
+			m_moonPosition += Scenes::Get()->GetCamera()->GetPosition();
 		}*/
 
-		*m_sunColour = SUN_COLOUR_SUNRISE.Interpolate(SUN_COLOUR_NIGHT, GetSunriseFactor());
-		*m_sunColour = m_sunColour->Interpolate(SUN_COLOUR_DAY, GetShadowFactor());
+		m_sunColour = SUN_COLOUR_SUNRISE.Interpolate(SUN_COLOUR_NIGHT, GetSunriseFactor());
+		m_sunColour = m_sunColour.Interpolate(SUN_COLOUR_DAY, GetShadowFactor());
 
-		*m_moonColour = MOON_COLOUR_NIGHT.Interpolate(MOON_COLOUR_DAY, GetShadowFactor());
+		m_moonColour = MOON_COLOUR_NIGHT.Interpolate(MOON_COLOUR_DAY, GetShadowFactor());
 
-		m_fog->SetColour(fogColour);
-		m_fog->SetDensity(0.002f + ((1.0f - GetShadowFactor()) * 0.002f));
-		m_fog->SetGradient(2.0f - ((1.0f - GetShadowFactor()) * 0.380f));
-		m_fog->SetLowerLimit(0.0f);
-		m_fog->SetUpperLimit(0.15f - ((1.0f - GetShadowFactor()) * 0.03f));
+		m_fog.SetColour(fogColour);
+		m_fog.SetDensity(0.002f + ((1.0f - GetShadowFactor()) * 0.002f));
+		m_fog.SetGradient(2.0f - ((1.0f - GetShadowFactor()) * 0.380f));
+		m_fog.SetLowerLimit(0.0f);
+		m_fog.SetUpperLimit(0.15f - ((1.0f - GetShadowFactor()) * 0.03f));
 
-		*m_skyColour = SKYBOX_COLOUR_DAY;
+		m_skyColour = SKYBOX_COLOUR_DAY;
 
 		if (Shadows::Get() != nullptr)
 		{
@@ -120,7 +108,7 @@ namespace fl
 
 	float Worlds::GetSunHeight() const
 	{
-		return m_sunPosition->m_y;
+		return m_sunPosition.m_y;
 	}
 
 	float Worlds::GetStarIntensity() const
@@ -130,7 +118,7 @@ namespace fl
 
 	float Worlds::GetTerrainRadius(const float &radius, const float &theta, const float &phi)
 	{
-		float height = m_noiseTerrain->GetValue(
+		float height = m_noiseTerrain.GetValue(
 			(radius / 10.0f) * Maths::NormalizeAngle(Maths::Degrees(theta)),
 			(radius / 10.0f) * Maths::NormalizeAngle(Maths::Degrees(phi))
 		);

--- a/Sources/Worlds/Worlds.cpp
+++ b/Sources/Worlds/Worlds.cpp
@@ -5,18 +5,18 @@
 
 namespace fl
 {
-	const Colour *Worlds::FOG_COLOUR_SUNRISE = new Colour("#ee9a90");
-	const Colour *Worlds::FOG_COLOUR_NIGHT = new Colour("#0D0D1A");
-	const Colour *Worlds::FOG_COLOUR_DAY = new Colour("#e6e6e6");
+	const Colour Worlds::FOG_COLOUR_SUNRISE = Colour("#ee9a90");
+	const Colour Worlds::FOG_COLOUR_NIGHT = Colour("#0D0D1A");
+	const Colour Worlds::FOG_COLOUR_DAY = Colour("#e6e6e6");
 
-	const Colour *Worlds::SUN_COLOUR_SUNRISE = new Colour("#ee9a90");
-	const Colour *Worlds::SUN_COLOUR_NIGHT = new Colour("#0D0D1A");
-	const Colour *Worlds::SUN_COLOUR_DAY = new Colour("#ffffff");
+	const Colour Worlds::SUN_COLOUR_SUNRISE = Colour("#ee9a90");
+	const Colour Worlds::SUN_COLOUR_NIGHT = Colour("#0D0D1A");
+	const Colour Worlds::SUN_COLOUR_DAY = Colour("#ffffff");
 
-	const Colour *Worlds::MOON_COLOUR_NIGHT = new Colour("#666699");
-	const Colour *Worlds::MOON_COLOUR_DAY = new Colour("#000000");
+	const Colour Worlds::MOON_COLOUR_NIGHT = Colour("#666699");
+	const Colour Worlds::MOON_COLOUR_DAY = Colour("#000000");
 
-	const Colour *Worlds::SKYBOX_COLOUR_DAY = new Colour("#003C8A");
+	const Colour Worlds::SKYBOX_COLOUR_DAY = Colour("#003C8A");
 
 	Worlds::Worlds() :
 		IModule(),
@@ -68,8 +68,8 @@ namespace fl
 		Vector3 lightDirection = m_skyboxRotation->Rotate(Vector3(0.2f, 0.0f, 0.5f));
 		lightDirection.Normalize();
 
-		Colour fogColour = FOG_COLOUR_SUNRISE->Interpolate(*FOG_COLOUR_NIGHT, GetSunriseFactor());
-		fogColour = fogColour.Interpolate(*FOG_COLOUR_DAY, GetShadowFactor());
+		Colour fogColour = FOG_COLOUR_SUNRISE.Interpolate(FOG_COLOUR_NIGHT, GetSunriseFactor());
+		fogColour = fogColour.Interpolate(FOG_COLOUR_DAY, GetShadowFactor());
 
 		*m_sunPosition = lightDirection * Vector3(-6048.0f, -6048.0f, -6048.0f);
 		*m_moonPosition = lightDirection * Vector3(6048.0f, 6048.0f, 6048.0f);
@@ -80,10 +80,10 @@ namespace fl
 			Vector3::Add(*m_moonPosition, *Scenes::Get()->GetCamera()->GetPosition(), m_moonPosition);
 		}*/
 
-		*m_sunColour = SUN_COLOUR_SUNRISE->Interpolate(*SUN_COLOUR_NIGHT, GetSunriseFactor());
-		*m_sunColour = m_sunColour->Interpolate(*SUN_COLOUR_DAY, GetShadowFactor());
+		*m_sunColour = SUN_COLOUR_SUNRISE.Interpolate(SUN_COLOUR_NIGHT, GetSunriseFactor());
+		*m_sunColour = m_sunColour->Interpolate(SUN_COLOUR_DAY, GetShadowFactor());
 
-		*m_moonColour = MOON_COLOUR_NIGHT->Interpolate(*MOON_COLOUR_DAY, GetShadowFactor());
+		*m_moonColour = MOON_COLOUR_NIGHT.Interpolate(MOON_COLOUR_DAY, GetShadowFactor());
 
 		m_fog->SetColour(fogColour);
 		m_fog->SetDensity(0.002f + ((1.0f - GetShadowFactor()) * 0.002f));
@@ -91,7 +91,7 @@ namespace fl
 		m_fog->SetLowerLimit(0.0f);
 		m_fog->SetUpperLimit(0.15f - ((1.0f - GetShadowFactor()) * 0.03f));
 
-		*m_skyColour = *SKYBOX_COLOUR_DAY;
+		*m_skyColour = SKYBOX_COLOUR_DAY;
 
 		if (Shadows::Get() != nullptr)
 		{

--- a/Sources/Worlds/Worlds.hpp
+++ b/Sources/Worlds/Worlds.hpp
@@ -15,18 +15,18 @@ namespace fl
 		public IModule
 	{
 	private:
-		static const Colour *FOG_COLOUR_SUNRISE;
-		static const Colour *FOG_COLOUR_NIGHT;
-		static const Colour *FOG_COLOUR_DAY;
+		static const Colour FOG_COLOUR_SUNRISE;
+		static const Colour FOG_COLOUR_NIGHT;
+		static const Colour FOG_COLOUR_DAY;
 
-		static const Colour *SUN_COLOUR_SUNRISE;
-		static const Colour *SUN_COLOUR_NIGHT;
-		static const Colour *SUN_COLOUR_DAY;
+		static const Colour SUN_COLOUR_SUNRISE;
+		static const Colour SUN_COLOUR_NIGHT;
+		static const Colour SUN_COLOUR_DAY;
 
-		static const Colour *MOON_COLOUR_NIGHT;
-		static const Colour *MOON_COLOUR_DAY;
+		static const Colour MOON_COLOUR_NIGHT;
+		static const Colour MOON_COLOUR_DAY;
 
-		static const Colour *SKYBOX_COLOUR_DAY;
+		static const Colour SKYBOX_COLOUR_DAY;
 
 		Noise *m_noiseTerrain;
 

--- a/Sources/Worlds/Worlds.hpp
+++ b/Sources/Worlds/Worlds.hpp
@@ -28,19 +28,19 @@ namespace fl
 
 		static const Colour SKYBOX_COLOUR_DAY;
 
-		Noise *m_noiseTerrain;
+		Noise m_noiseTerrain;
 
-		DriverLinear *m_driverDay;
+		DriverLinear m_driverDay;
 		float m_factorDay;
 
-		Vector3 *m_skyboxRotation;
-		Vector3 *m_sunPosition;
-		Vector3 *m_moonPosition;
-		Colour *m_sunColour;
-		Colour *m_moonColour;
+		Vector3 m_skyboxRotation;
+		Vector3 m_sunPosition;
+		Vector3 m_moonPosition;
+		Colour m_sunColour;
+		Colour m_moonColour;
 
-		Fog *m_fog;
-		Colour *m_skyColour;
+		Fog m_fog;
+		Colour m_skyColour;
 	public:
 		/// <summary>
 		/// Gets this engine instance.
@@ -75,24 +75,24 @@ namespace fl
 
 		float GetTerrainRadius(const float &radius, const float &theta, const float &phi);
 
-		Noise *GetNoiseTerrain() const { return m_noiseTerrain; }
+		Noise GetNoiseTerrain() const { return m_noiseTerrain; }
 
-		Vector3 *GetSkyboxRotation() const { return m_skyboxRotation; }
+		Vector3 GetSkyboxRotation() const { return m_skyboxRotation; }
 
-		Vector3 *GetSunPosition() const { return m_sunPosition; }
+		Vector3 GetSunPosition() const { return m_sunPosition; }
 
-		Vector3 *GetMoonPosition() const { return m_moonPosition; }
+		Vector3 GetMoonPosition() const { return m_moonPosition; }
 
-		Colour *GetSunColour() const { return m_sunColour; }
+		Colour GetSunColour() const { return m_sunColour; }
 
-		Colour *GetMoonColour() const { return m_moonColour; }
+		Colour GetMoonColour() const { return m_moonColour; }
 
-		Fog *GetFog() const { return m_fog; }
+		Fog GetFog() const { return m_fog; }
 
-		void SetFog(const Fog &fog) { *m_fog = fog; }
+		void SetFog(const Fog &fog) { m_fog = fog; }
 
-		Colour *GetSkyColour() const { return m_skyColour; }
+		Colour GetSkyColour() const { return m_skyColour; }
 
-		void SetSkyColour(const Colour &skyColour) { *m_skyColour = skyColour; }
+		void SetSkyColour(const Colour &skyColour) { m_skyColour = skyColour; }
 	};
 }

--- a/Tests/TestDeferred/Configs/ConfigManager.cpp
+++ b/Tests/TestDeferred/Configs/ConfigManager.cpp
@@ -8,21 +8,21 @@
 
 namespace test
 {
-	ConfigManager::ConfigManager()
+	ConfigManager::ConfigManager() :
+		m_configAudio(Config(new FileJson(FileSystem::GetWorkingDirectory() + "/Configs/Audio.json"))),
+		m_configGraphics(Config(new FileJson(FileSystem::GetWorkingDirectory() + "/Configs/Graphics.json")))
 	{
 		FileSystem::CreateFolder("Configs");
 
-		m_configAudio = new Config(new FileJson(FileSystem::GetWorkingDirectory() + "/Configs/Audio.json"));
-		m_configAudio->Load();
-		//	m_configAudio->Link<float>("MasterVolume", 1.0f, nullptr, nullptr);
+		m_configAudio.Load();
+		//	m_configAudio.Link<float>("MasterVolume", 1.0f, nullptr, nullptr);
 
-		m_configGraphics = new Config(new FileJson(FileSystem::GetWorkingDirectory() + "/Configs/Graphics.json"));
-		m_configGraphics->Load();
-		m_configGraphics->Link<int>("Display Width", 1080, CONFIG_GET(Display::Get()->GetWindowWidth()), CONFIG_SET(int, Display::Get()->SetWidth(v)));
-		m_configGraphics->Link<int>("Display Height", 720, CONFIG_GET(Display::Get()->GetWindowHeight()), CONFIG_SET(int, Display::Get()->SetHeight(v)));
-		m_configGraphics->Link<float>("Fps Limit", 0.0f, CONFIG_GET(Engine::Get()->GetFpsLimit()), CONFIG_SET(float, Engine::Get()->SetFpsLimit(v)));
-		m_configGraphics->Link<bool>("Is Antialiasing", true, CONFIG_GET(Display::Get()->IsAntialiasing()), CONFIG_SET(bool, Display::Get()->SetAntialiasing(v)));
-		m_configGraphics->Link<bool>("Is Fullscreen", false, CONFIG_GET(Display::Get()->IsFullscreen()), CONFIG_SET(bool, Display::Get()->SetFullscreen(v)));
+		m_configGraphics.Load();
+		m_configGraphics.Link<int>("Display Width", 1080, CONFIG_GET(Display::Get()->GetWindowWidth()), CONFIG_SET(int, Display::Get()->SetWidth(v)));
+		m_configGraphics.Link<int>("Display Height", 720, CONFIG_GET(Display::Get()->GetWindowHeight()), CONFIG_SET(int, Display::Get()->SetHeight(v)));
+		m_configGraphics.Link<float>("Fps Limit", 0.0f, CONFIG_GET(Engine::Get()->GetFpsLimit()), CONFIG_SET(float, Engine::Get()->SetFpsLimit(v)));
+		m_configGraphics.Link<bool>("Is Antialiasing", true, CONFIG_GET(Display::Get()->IsAntialiasing()), CONFIG_SET(bool, Display::Get()->SetAntialiasing(v)));
+		m_configGraphics.Link<bool>("Is Fullscreen", false, CONFIG_GET(Display::Get()->IsFullscreen()), CONFIG_SET(bool, Display::Get()->SetFullscreen(v)));
 
 		Events::Get()->AddEvent(new EventTime(2.5f, false, [&]() -> void
 		{
@@ -33,15 +33,12 @@ namespace test
 	ConfigManager::~ConfigManager()
 	{
 		Save();
-
-		delete m_configAudio;
-		delete m_configGraphics;
 	}
 
 	void ConfigManager::Save()
 	{
 		printf("Saving config manager\n");
-		m_configAudio->Save();
-		m_configGraphics->Save();
+		m_configAudio.Save();
+		m_configGraphics.Save();
 	}
 }

--- a/Tests/TestDeferred/Configs/ConfigManager.hpp
+++ b/Tests/TestDeferred/Configs/ConfigManager.hpp
@@ -9,8 +9,8 @@ namespace test
 	class ConfigManager
 	{
 	private:
-		Config *m_configAudio;
-		Config *m_configGraphics;
+		Config m_configAudio;
+		Config m_configGraphics;
 	public:
 		ConfigManager();
 

--- a/Tests/TestDeferred/MainRenderer.cpp
+++ b/Tests/TestDeferred/MainRenderer.cpp
@@ -111,7 +111,7 @@ namespace test
 
 		// Subpass 0.
 		m_rendererMeshes->Render(*commandBuffer, m_infinity, *camera);
-		//	m_rendererParticles->Render(*commandBuffer, m_infinity, *camera);
+	//	m_rendererParticles->Render(*commandBuffer, m_infinity, *camera);
 		Renderer::Get()->NextSubpass(*commandBuffer);
 
 		// Subpass 1.

--- a/Tests/TestDeferred/MainRenderer.cpp
+++ b/Tests/TestDeferred/MainRenderer.cpp
@@ -78,8 +78,8 @@ namespace test
 		RENDERPASS_0_CREATE->SetWidth(Shadows::Get()->GetShadowSize());
 		RENDERPASS_0_CREATE->SetHeight(Shadows::Get()->GetShadowSize());
 
-		const auto commandBuffer = Renderer::Get()->GetCommandBuffer();
-		const auto camera = Scenes::Get()->GetCamera();
+		auto commandBuffer = Renderer::Get()->GetCommandBuffer();
+		auto camera = Scenes::Get()->GetCamera();
 
 		// Starts Rendering.
 		auto startResult = Renderer::Get()->StartRenderpass(*commandBuffer, 0);
@@ -98,8 +98,8 @@ namespace test
 
 	void MainRenderer::RenderPass1()
 	{
-		const auto commandBuffer = Renderer::Get()->GetCommandBuffer();
-		const auto camera = Scenes::Get()->GetCamera();
+		auto commandBuffer = Renderer::Get()->GetCommandBuffer();
+		auto camera = Scenes::Get()->GetCamera();
 
 		// Starts Rendering.
 		auto startResult = Renderer::Get()->StartRenderpass(*commandBuffer, 1);

--- a/Tests/TestDeferred/Scenes/FpsCamera.cpp
+++ b/Tests/TestDeferred/Scenes/FpsCamera.cpp
@@ -27,17 +27,17 @@ namespace test
 	const float FpsCamera::MIN_ANGLE_OF_ELEVATION = -85.0f;
 
 	FpsCamera::FpsCamera() :
-		m_position(new Vector3()),
-		m_velocity(new Vector3()),
-		m_rotation(new Vector3()),
-		m_viewMatrix(new Matrix4()),
-		m_projectionMatrix(new Matrix4()),
-		m_viewFrustum(new Frustum()),
-		m_viewRay(new Ray(false, Vector2(0.5f, 0.5f))),
+		m_position(Vector3()),
+		m_velocity(Vector3()),
+		m_rotation(Vector3()),
+		m_viewMatrix(Matrix4()),
+		m_projectionMatrix(Matrix4()),
+		m_viewFrustum(Frustum()),
+		m_viewRay(Ray(false, Vector2(0.5f, 0.5f))),
 		m_angleOfElevation(25.0f),
 		m_angleAroundPlayer(0.0f),
-		m_targetPosition(new Vector3()),
-		m_targetRotation(new Vector3()),
+		m_targetPosition(Vector3()),
+		m_targetRotation(Vector3()),
 		m_targetElevation(m_angleOfElevation),
 		m_targetRotationAngle(m_angleAroundPlayer),
 		m_sensitivity(0.9f),
@@ -50,19 +50,6 @@ namespace test
 
 	FpsCamera::~FpsCamera()
 	{
-		delete m_position;
-		delete m_velocity;
-		delete m_rotation;
-
-		delete m_viewMatrix;
-		delete m_projectionMatrix;
-
-		delete m_viewFrustum;
-		delete m_viewRay;
-
-		delete m_targetPosition;
-		delete m_targetRotation;
-
 		delete m_joystickVertical;
 		delete m_joystickHorizontal;
 	}
@@ -90,20 +77,20 @@ namespace test
 			auto playerRotation = player->GetGameObject()->GetTransform()->GetRotation();
 			auto playerPosition = player->GetGameObject()->GetTransform()->GetPosition();
 
-			*m_velocity = (playerPosition - *m_targetPosition) / delta;
-			*m_targetPosition = playerPosition;
-			*m_targetRotation = playerRotation;
+			m_velocity = (playerPosition - m_targetPosition) / delta;
+			m_targetPosition = playerPosition;
+			m_targetRotation = playerRotation;
 		}
 
 		UpdateHorizontalAngle(delta);
 		UpdatePitchAngle(delta);
 		UpdatePosition();
 
-		*m_viewMatrix = Matrix4::ViewMatrix(*m_position, *m_rotation);
-		*m_projectionMatrix = Matrix4::PerspectiveMatrix(GetFov(), Display::Get()->GetAspectRatio(), GetNearPlane(), GetFarPlane());
+		m_viewMatrix = Matrix4::ViewMatrix(m_position, m_rotation);
+		m_projectionMatrix = Matrix4::PerspectiveMatrix(GetFov(), Display::Get()->GetAspectRatio(), GetNearPlane(), GetFarPlane());
 
-		m_viewFrustum->Update(*m_viewMatrix, *m_projectionMatrix);
-		m_viewRay->Update(*m_position, Vector2(Mouse::Get()->GetPositionX(), Mouse::Get()->GetPositionY()), *m_viewMatrix, *m_projectionMatrix);
+		m_viewFrustum.Update(m_viewMatrix, m_projectionMatrix);
+		m_viewRay.Update(m_position, Vector2(Mouse::Get()->GetPositionX(), Mouse::Get()->GetPositionY()), m_viewMatrix, m_projectionMatrix);
 	}
 
 	void FpsCamera::CalculateHorizontalAngle()
@@ -238,16 +225,16 @@ namespace test
 
 	void FpsCamera::UpdatePosition()
 	{
-		*m_position = *m_targetPosition;
-		m_rotation->m_x = m_angleOfElevation - m_targetRotation->m_z;
-		m_rotation->m_y = m_angleAroundPlayer + m_targetRotation->m_y + 180.0f;
-		m_rotation->m_z = 0.0f;
+		m_position = m_targetPosition;
+		m_rotation.m_x = m_angleOfElevation - m_targetRotation.m_z;
+		m_rotation.m_y = m_angleAroundPlayer + m_targetRotation.m_y + 180.0f;
+		m_rotation.m_z = 0.0f;
 	}
 
 	void FpsCamera::ReflectView(const float &waterHeight)
 	{
-		m_position->m_y -= 2.0f * (m_position->m_y - waterHeight);
-		m_rotation->m_x = -m_rotation->m_x;
-		*m_viewMatrix = Matrix4::ViewMatrix(*m_position, *m_rotation);
+		m_position.m_y -= 2.0f * (m_position.m_y - waterHeight);
+		m_rotation.m_x = -m_rotation.m_x;
+		m_viewMatrix = Matrix4::ViewMatrix(m_position, m_rotation);
 	}
 }

--- a/Tests/TestDeferred/Scenes/FpsCamera.cpp
+++ b/Tests/TestDeferred/Scenes/FpsCamera.cpp
@@ -90,9 +90,9 @@ namespace test
 			auto playerRotation = player->GetGameObject()->GetTransform()->GetRotation();
 			auto playerPosition = player->GetGameObject()->GetTransform()->GetPosition();
 
-			*m_velocity = (*playerPosition - *m_targetPosition) / delta;
-			*m_targetPosition = *playerPosition;
-			*m_targetRotation = *playerRotation;
+			*m_velocity = (playerPosition - *m_targetPosition) / delta;
+			*m_targetPosition = playerPosition;
+			*m_targetRotation = playerRotation;
 		}
 
 		UpdateHorizontalAngle(delta);

--- a/Tests/TestDeferred/Scenes/FpsCamera.cpp
+++ b/Tests/TestDeferred/Scenes/FpsCamera.cpp
@@ -231,9 +231,9 @@ namespace test
 		m_rotation.m_z = 0.0f;
 	}
 
-	void FpsCamera::ReflectView(const float &waterHeight)
+	void FpsCamera::ReflectView(const float &height)
 	{
-		m_position.m_y -= 2.0f * (m_position.m_y - waterHeight);
+		m_position.m_y -= 2.0f * (m_position.m_y - height);
 		m_rotation.m_x = -m_rotation.m_x;
 		m_viewMatrix = Matrix4::ViewMatrix(m_position, m_rotation);
 	}

--- a/Tests/TestDeferred/Scenes/FpsCamera.hpp
+++ b/Tests/TestDeferred/Scenes/FpsCamera.hpp
@@ -32,21 +32,21 @@ namespace test
 		static const float MAX_ANGLE_OF_ELEVATION;
 		static const float MIN_ANGLE_OF_ELEVATION;
 
-		Vector3 *m_position;
-		Vector3 *m_velocity;
-		Vector3 *m_rotation;
+		Vector3 m_position;
+		Vector3 m_velocity;
+		Vector3 m_rotation;
 
-		Matrix4 *m_viewMatrix;
-		Matrix4 *m_projectionMatrix;
+		Matrix4 m_viewMatrix;
+		Matrix4 m_projectionMatrix;
 
-		Frustum *m_viewFrustum;
-		Ray *m_viewRay;
+		Frustum m_viewFrustum;
+		Ray m_viewRay;
 
 		float m_angleOfElevation;
 		float m_angleAroundPlayer;
 
-		Vector3 *m_targetPosition;
-		Vector3 *m_targetRotation;
+		Vector3 m_targetPosition;
+		Vector3 m_targetRotation;
 		float m_targetElevation;
 		float m_targetRotationAngle;
 
@@ -83,18 +83,18 @@ namespace test
 
 		float GetFov() const override { return FIELD_OF_VIEW; }
 
-		Frustum *GetViewFrustum() const override { return m_viewFrustum; }
+		Frustum GetViewFrustum() const override { return m_viewFrustum; }
 
-		Ray *GetViewRay() const override { return m_viewRay; }
+		Ray GetViewRay() const override { return m_viewRay; }
 
-		Matrix4 *GetViewMatrix() const override { return m_viewMatrix; }
+		Matrix4 GetViewMatrix() const override { return m_viewMatrix; }
 
-		Matrix4 *GetProjectionMatrix() const override { return m_projectionMatrix; }
+		Matrix4 GetProjectionMatrix() const override { return m_projectionMatrix; }
 
-		Vector3 *GetPosition() const override { return m_position; }
+		Vector3 GetPosition() const override { return m_position; }
 
-		Vector3 *GetVelocity() const override { return m_velocity; }
+		Vector3 GetVelocity() const override { return m_velocity; }
 
-		Vector3 *GetRotation() const override { return m_rotation; }
+		Vector3 GetRotation() const override { return m_rotation; }
 	};
 }

--- a/Tests/TestDeferred/Scenes/FpsCamera.hpp
+++ b/Tests/TestDeferred/Scenes/FpsCamera.hpp
@@ -75,7 +75,7 @@ namespace test
 		void UpdatePosition();
 
 	public:
-		void ReflectView(const float &waterHeight) override;
+		void ReflectView(const float &height) override;
 
 		float GetNearPlane() const override { return NEAR_PLANE; }
 

--- a/Tests/TestDeferred/Scenes/FpsPlayer.cpp
+++ b/Tests/TestDeferred/Scenes/FpsPlayer.cpp
@@ -132,7 +132,7 @@ namespace test
 		float groundHeight = 0.0f;
 
 		// Calculates the deltas to the moved distance, and rotation.
-		float theta = Maths::Radians(cameraRotation->m_y);
+		float theta = Maths::Radians(cameraRotation.m_y);
 		float dx = -(m_velocity->m_z * std::sin(theta) + m_velocity->m_x * std::cos(theta)) * delta;
 		float dy = m_velocity->m_y * delta;
 		float dz = -(m_velocity->m_z * std::cos(theta) - m_velocity->m_x * std::sin(theta)) * delta;

--- a/Tests/TestDeferred/Scenes/FpsPlayer.cpp
+++ b/Tests/TestDeferred/Scenes/FpsPlayer.cpp
@@ -126,8 +126,8 @@ namespace test
 		*m_velocity = m_velocity->SmoothDamp(targetVelocity, delta * (m_noclipEnabled ? DAMP_NOCLIP : DAMP_NORMAL));
 
 		auto cameraRotation = Scenes::Get()->GetCamera()->GetRotation();
-		auto position = GetGameObject()->GetTransform()->GetPosition();
-		auto rotation = GetGameObject()->GetTransform()->GetRotation();
+		Vector3 newPosition = GetGameObject()->GetTransform()->GetPosition();
+		Vector3 newRotation = GetGameObject()->GetTransform()->GetRotation();
 
 		float groundHeight = 0.0f;
 
@@ -140,14 +140,17 @@ namespace test
 		*m_amountMove = Vector3(dx, dy, dz);
 		*m_amountRotate = Vector3(0.0f, 0.0f, 0.0f);
 
-		*position = *position + *m_amountMove;
-		*rotation = *rotation + *m_amountRotate;
+		newPosition += *m_amountMove;
+		newRotation += *m_amountRotate;
 
-		if (!m_noclipEnabled && position->m_y <= groundHeight)
+		if (!m_noclipEnabled && newPosition.m_y <= groundHeight)
 		{
 			m_velocity->m_y = 0.0f;
 			m_jumping = false;
-			position->m_y = groundHeight;
+			newPosition.m_y = groundHeight;
 		}
+
+		GetGameObject()->GetTransform()->SetPosition(newPosition);
+		GetGameObject()->GetTransform()->SetRotation(newRotation);
 	}
 }

--- a/Tests/TestDeferred/Scenes/ManagerUis.cpp
+++ b/Tests/TestDeferred/Scenes/ManagerUis.cpp
@@ -13,10 +13,10 @@ namespace test
 	ManagerUis::ManagerUis() :
 		IManagerUis(),
 		m_primaryColour(new Colour("#e74c3c")),
+		m_selectorJoystick(new SelectorJoystick(JoystickPort::JOYSTICK_1, 0, 1, 0, 1)),
 		m_uiStartLogo(new UiStartLogo(Uis::Get()->GetContainer())),
 		m_overlayDebug(new OverlayDebug(Uis::Get()->GetContainer()))
 	{
-		Uis::Get()->GetSelector()->Load(JoystickPort::JOYSTICK_1, 0, 1, 0, 1);
 		m_uiStartLogo->SetAlphaDriver(new DriverConstant(1.0f));
 		m_overlayDebug->SetAlphaDriver(new DriverConstant(0.0f));
 	}
@@ -24,6 +24,7 @@ namespace test
 	ManagerUis::~ManagerUis()
 	{
 		delete m_primaryColour;
+		delete m_selectorJoystick;
 		delete m_uiStartLogo;
 		delete m_overlayDebug;
 	}

--- a/Tests/TestDeferred/Scenes/ManagerUis.hpp
+++ b/Tests/TestDeferred/Scenes/ManagerUis.hpp
@@ -11,14 +11,15 @@ namespace test
 	class ManagerUis :
 		public IManagerUis
 	{
-	public:
-		static const float SLIDE_TIME;
 	private:
 		Colour *m_primaryColour;
+		SelectorJoystick *m_selectorJoystick;
 
 		UiStartLogo *m_uiStartLogo;
 		OverlayDebug *m_overlayDebug;
 	public:
+		static const float SLIDE_TIME;
+
 		ManagerUis();
 
 		~ManagerUis();
@@ -29,6 +30,8 @@ namespace test
 
 		float GetBlurFactor() override;
 
-		Colour *GetPrimaryColour() override { return m_primaryColour; }
+		Colour *GetPrimaryColour() const override { return m_primaryColour; }
+
+		SelectorJoystick *GetSelectorJoystick() const override { return m_selectorJoystick; };
 	};
 }

--- a/Tests/TestDeferred/Uis/OverlayDebug.cpp
+++ b/Tests/TestDeferred/Uis/OverlayDebug.cpp
@@ -55,10 +55,10 @@ namespace test
 
 			if (Scenes::Get()->GetCamera() != nullptr)
 			{
-				Vector3 *cameraPosition = Scenes::Get()->GetCamera()->GetPosition();
-				m_textPosition->SetString("POS: " + std::to_string(static_cast<int>(cameraPosition->m_x)) + ", " +
-					std::to_string(static_cast<int>(cameraPosition->m_y)) + ", " +
-					std::to_string(static_cast<int>(cameraPosition->m_z)));
+				Vector3 cameraPosition = Scenes::Get()->GetCamera()->GetPosition();
+				m_textPosition->SetString("POS: " + std::to_string(static_cast<int>(cameraPosition.m_x)) + ", " +
+					std::to_string(static_cast<int>(cameraPosition.m_y)) + ", " +
+					std::to_string(static_cast<int>(cameraPosition.m_z)));
 			}
 
 			m_textFps->SetString("FPS: " + std::to_string(static_cast<int>(1.0 / Engine::Get()->GetDeltaRender())));

--- a/Tests/TestGuis/MainRenderer.cpp
+++ b/Tests/TestGuis/MainRenderer.cpp
@@ -32,8 +32,8 @@ namespace test
 
 	void MainRenderer::Render()
 	{
-		const auto commandBuffer = Renderer::Get()->GetCommandBuffer();
-		const auto camera = Scenes::Get()->GetCamera();
+		auto commandBuffer = Renderer::Get()->GetCommandBuffer();
+		auto camera = Scenes::Get()->GetCamera();
 
 		// Starts Rendering.
 		auto startResult = Renderer::Get()->StartRenderpass(*commandBuffer, 0);

--- a/Tests/TestGuis/Scenes/FpsCamera.cpp
+++ b/Tests/TestGuis/Scenes/FpsCamera.cpp
@@ -11,44 +11,35 @@ namespace test
 	const float FpsCamera::FIELD_OF_VIEW = 60.0f;
 
 	FpsCamera::FpsCamera() :
-		m_position(new Vector3()),
-		m_velocity(new Vector3()),
-		m_rotation(new Vector3()),
-		m_viewMatrix(new Matrix4()),
-		m_projectionMatrix(new Matrix4()),
-		m_viewFrustum(new Frustum()),
-		m_viewRay(new Ray(false, Vector2(0.5f, 0.5f)))
+		m_position(Vector3()),
+		m_velocity(Vector3()),
+		m_rotation(Vector3()),
+		m_viewMatrix(Matrix4()),
+		m_projectionMatrix(Matrix4()),
+		m_viewFrustum(Frustum()),
+		m_viewRay(Ray(false, Vector2(0.5f, 0.5f)))
 	{
 	}
 
 	FpsCamera::~FpsCamera()
 	{
-		delete m_position;
-		delete m_velocity;
-		delete m_rotation;
-
-		delete m_viewMatrix;
-		delete m_projectionMatrix;
-
-		delete m_viewFrustum;
-		delete m_viewRay;
 	}
 
 	void FpsCamera::Update()
 	{
 	//	float delta = std::min(1.0f / 60.0f, Engine::Get()->GetDelta());
 
-		*m_viewMatrix = Matrix4::ViewMatrix(*m_position, *m_rotation);
-		*m_projectionMatrix = Matrix4::PerspectiveMatrix(GetFov(), Display::Get()->GetAspectRatio(), GetNearPlane(), GetFarPlane());
+		m_viewMatrix = Matrix4::ViewMatrix(m_position, m_rotation);
+		m_projectionMatrix = Matrix4::PerspectiveMatrix(GetFov(), Display::Get()->GetAspectRatio(), GetNearPlane(), GetFarPlane());
 
-		m_viewFrustum->Update(*m_viewMatrix, *m_projectionMatrix);
-		m_viewRay->Update(*m_position, Vector2(Mouse::Get()->GetPositionX(), Mouse::Get()->GetPositionY()), *m_viewMatrix, *m_projectionMatrix);
+		m_viewFrustum.Update(m_viewMatrix, m_projectionMatrix);
+		m_viewRay.Update(m_position, Vector2(Mouse::Get()->GetPositionX(), Mouse::Get()->GetPositionY()), m_viewMatrix, m_projectionMatrix);
 	}
 
 	void FpsCamera::ReflectView(const float &waterHeight)
 	{
-		m_position->m_y -= 2.0f * (m_position->m_y - waterHeight);
-		m_rotation->m_x = -m_rotation->m_x;
-		*m_viewMatrix = Matrix4::ViewMatrix(*m_position, *m_rotation);
+		m_position.m_y -= 2.0f * (m_position.m_y - waterHeight);
+		m_rotation.m_x = -m_rotation.m_x;
+		m_viewMatrix = Matrix4::ViewMatrix(m_position, m_rotation);
 	}
 }

--- a/Tests/TestGuis/Scenes/FpsCamera.cpp
+++ b/Tests/TestGuis/Scenes/FpsCamera.cpp
@@ -36,9 +36,9 @@ namespace test
 		m_viewRay.Update(m_position, Vector2(Mouse::Get()->GetPositionX(), Mouse::Get()->GetPositionY()), m_viewMatrix, m_projectionMatrix);
 	}
 
-	void FpsCamera::ReflectView(const float &waterHeight)
+	void FpsCamera::ReflectView(const float &height)
 	{
-		m_position.m_y -= 2.0f * (m_position.m_y - waterHeight);
+		m_position.m_y -= 2.0f * (m_position.m_y - height);
 		m_rotation.m_x = -m_rotation.m_x;
 		m_viewMatrix = Matrix4::ViewMatrix(m_position, m_rotation);
 	}

--- a/Tests/TestGuis/Scenes/FpsCamera.hpp
+++ b/Tests/TestGuis/Scenes/FpsCamera.hpp
@@ -32,7 +32,7 @@ namespace test
 
 		void Update() override;
 
-		void ReflectView(const float &waterHeight) override;
+		void ReflectView(const float &height) override;
 
 		float GetNearPlane() const override { return NEAR_PLANE; }
 

--- a/Tests/TestGuis/Scenes/FpsCamera.hpp
+++ b/Tests/TestGuis/Scenes/FpsCamera.hpp
@@ -16,15 +16,15 @@ namespace test
 		static const float FAR_PLANE;
 		static const float FIELD_OF_VIEW;
 
-		Vector3 *m_position;
-		Vector3 *m_velocity;
-		Vector3 *m_rotation;
+		Vector3 m_position;
+		Vector3 m_velocity;
+		Vector3 m_rotation;
 
-		Matrix4 *m_viewMatrix;
-		Matrix4 *m_projectionMatrix;
+		Matrix4 m_viewMatrix;
+		Matrix4 m_projectionMatrix;
 
-		Frustum *m_viewFrustum;
-		Ray *m_viewRay;
+		Frustum m_viewFrustum;
+		Ray m_viewRay;
 	public:
 		FpsCamera();
 
@@ -40,18 +40,18 @@ namespace test
 
 		float GetFov() const override { return FIELD_OF_VIEW; }
 
-		Frustum *GetViewFrustum() const override { return m_viewFrustum; }
+		Frustum GetViewFrustum() const override { return m_viewFrustum; }
 
-		Ray *GetViewRay() const override { return m_viewRay; }
+		Ray GetViewRay() const override { return m_viewRay; }
 
-		Matrix4 *GetViewMatrix() const override { return m_viewMatrix; }
+		Matrix4 GetViewMatrix() const override { return m_viewMatrix; }
 
-		Matrix4 *GetProjectionMatrix() const override { return m_projectionMatrix; }
+		Matrix4 GetProjectionMatrix() const override { return m_projectionMatrix; }
 
-		Vector3 *GetPosition() const override { return m_position; }
+		Vector3 GetPosition() const override { return m_position; }
 
-		Vector3 *GetVelocity() const override { return m_velocity; }
+		Vector3 GetVelocity() const override { return m_velocity; }
 
-		Vector3 *GetRotation() const override { return m_rotation; }
+		Vector3 GetRotation() const override { return m_rotation; }
 	};
 }

--- a/Tests/TestGuis/Scenes/ManagerUis.cpp
+++ b/Tests/TestGuis/Scenes/ManagerUis.cpp
@@ -11,8 +11,8 @@ namespace test
 
 	ManagerUis::ManagerUis() :
 		IManagerUis(),
-		m_primaryColour(new Colour("#e74c3c")),
-		m_selectorJoystick(new SelectorJoystick(JoystickPort::JOYSTICK_1, 0, 1, 0, 1)),
+		m_primaryColour(Colour("#e74c3c")),
+		m_selectorJoystick(SelectorJoystick(JoystickPort::JOYSTICK_1, 0, 1, 0, 1)),
 		m_buttonPause((new ButtonCompound({
 			new ButtonKeyboard({Key::KEY_ESCAPE}),
 			new ButtonJoystick(JoystickPort::JOYSTICK_1, {7})
@@ -28,8 +28,6 @@ namespace test
 
 	ManagerUis::~ManagerUis()
 	{
-		delete m_primaryColour;
-		delete m_selectorJoystick;
 		delete m_buttonPause;
 		delete m_uiStartLogo;
 		delete m_overlayDebug;

--- a/Tests/TestGuis/Scenes/ManagerUis.cpp
+++ b/Tests/TestGuis/Scenes/ManagerUis.cpp
@@ -12,6 +12,7 @@ namespace test
 	ManagerUis::ManagerUis() :
 		IManagerUis(),
 		m_primaryColour(new Colour("#e74c3c")),
+		m_selectorJoystick(new SelectorJoystick(JoystickPort::JOYSTICK_1, 0, 1, 0, 1)),
 		m_buttonPause((new ButtonCompound({
 			new ButtonKeyboard({Key::KEY_ESCAPE}),
 			new ButtonJoystick(JoystickPort::JOYSTICK_1, {7})
@@ -20,7 +21,6 @@ namespace test
 		m_overlayDebug(new OverlayDebug(Uis::Get()->GetContainer())),
 		m_uiNavigation(new UiNavigation(Uis::Get()->GetContainer()))
 	{
-		Uis::Get()->GetSelector()->Load(JoystickPort::JOYSTICK_1, 0, 1, 0, 1);
 		m_uiStartLogo->SetAlphaDriver(new DriverConstant(1.0f));
 		m_overlayDebug->SetAlphaDriver(new DriverConstant(0.0f));
 		m_uiNavigation->SetAlphaDriver(new DriverConstant(0.0f));
@@ -29,6 +29,7 @@ namespace test
 	ManagerUis::~ManagerUis()
 	{
 		delete m_primaryColour;
+		delete m_selectorJoystick;
 		delete m_buttonPause;
 		delete m_uiStartLogo;
 		delete m_overlayDebug;

--- a/Tests/TestGuis/Scenes/ManagerUis.cpp
+++ b/Tests/TestGuis/Scenes/ManagerUis.cpp
@@ -11,8 +11,8 @@ namespace test
 
 	ManagerUis::ManagerUis() :
 		IManagerUis(),
-		m_primaryColour(Colour("#e74c3c")),
-		m_selectorJoystick(SelectorJoystick(JoystickPort::JOYSTICK_1, 0, 1, 0, 1)),
+		m_primaryColour(new Colour("#e74c3c")),
+		m_selectorJoystick(new SelectorJoystick(JoystickPort::JOYSTICK_1, 0, 1, 0, 1)),
 		m_buttonPause((new ButtonCompound({
 			new ButtonKeyboard({Key::KEY_ESCAPE}),
 			new ButtonJoystick(JoystickPort::JOYSTICK_1, {7})
@@ -28,6 +28,9 @@ namespace test
 
 	ManagerUis::~ManagerUis()
 	{
+		delete m_primaryColour;
+		delete m_selectorJoystick;
+
 		delete m_buttonPause;
 		delete m_uiStartLogo;
 		delete m_overlayDebug;

--- a/Tests/TestGuis/Scenes/ManagerUis.hpp
+++ b/Tests/TestGuis/Scenes/ManagerUis.hpp
@@ -15,8 +15,8 @@ namespace test
 	public:
 		static const float SLIDE_TIME;
 	private:
-		Colour m_primaryColour;
-		SelectorJoystick m_selectorJoystick;
+		Colour *m_primaryColour;
+		SelectorJoystick *m_selectorJoystick;
 
 		IButton *m_buttonPause;
 
@@ -34,9 +34,9 @@ namespace test
 
 		float GetBlurFactor() override;
 
-		Colour GetPrimaryColour() const override { return m_primaryColour; }
+		Colour *GetPrimaryColour() const override { return m_primaryColour; }
 
-		SelectorJoystick GetSelectorJoystick() const override { return m_selectorJoystick; };
+		SelectorJoystick *GetSelectorJoystick() const override { return m_selectorJoystick; };
 	private:
 		void TogglePause();
 	};

--- a/Tests/TestGuis/Scenes/ManagerUis.hpp
+++ b/Tests/TestGuis/Scenes/ManagerUis.hpp
@@ -16,6 +16,7 @@ namespace test
 		static const float SLIDE_TIME;
 	private:
 		Colour *m_primaryColour;
+		SelectorJoystick *m_selectorJoystick;
 
 		IButton *m_buttonPause;
 
@@ -33,7 +34,9 @@ namespace test
 
 		float GetBlurFactor() override;
 
-		Colour *GetPrimaryColour() override { return m_primaryColour; }
+		Colour *GetPrimaryColour() const override { return m_primaryColour; }
+
+		SelectorJoystick *GetSelectorJoystick() const override { return m_selectorJoystick; };
 	private:
 		void TogglePause();
 	};

--- a/Tests/TestGuis/Scenes/ManagerUis.hpp
+++ b/Tests/TestGuis/Scenes/ManagerUis.hpp
@@ -15,8 +15,8 @@ namespace test
 	public:
 		static const float SLIDE_TIME;
 	private:
-		Colour *m_primaryColour;
-		SelectorJoystick *m_selectorJoystick;
+		Colour m_primaryColour;
+		SelectorJoystick m_selectorJoystick;
 
 		IButton *m_buttonPause;
 
@@ -34,9 +34,9 @@ namespace test
 
 		float GetBlurFactor() override;
 
-		Colour *GetPrimaryColour() const override { return m_primaryColour; }
+		Colour GetPrimaryColour() const override { return m_primaryColour; }
 
-		SelectorJoystick *GetSelectorJoystick() const override { return m_selectorJoystick; };
+		SelectorJoystick GetSelectorJoystick() const override { return m_selectorJoystick; };
 	private:
 		void TogglePause();
 	};

--- a/Tests/TestGuis/Uis/Navigation/UiNavigation.cpp
+++ b/Tests/TestGuis/Uis/Navigation/UiNavigation.cpp
@@ -26,8 +26,8 @@ namespace test
 		m_currentTab(nullptr),
 		m_targetTab(nullptr)
 	{
-		Texture *textureWhite = new Texture("Resources/Guis/White.png");
-		Texture *textureGeometry = new Texture("Resources/Guis/Geometry-Grain.png");
+		auto textureWhite = Texture::Resource("Resources/Guis/White.png");
+		auto textureGeometry = Texture::Resource("Resources/Guis/Geometry-Grain.png");
 
 		m_barBackground = new Gui(this, UiBound(Vector2(0.5f, 1.0f), "TopCentre", true, false, Vector2(1.0f, 1.0f)), textureGeometry, 1);
 		m_barBackground->SetScissor(Vector4(0.0f, 0.0f, 1.0f, 0.125f));

--- a/Tests/TestGuis/Uis/Navigation/UiNavigation.cpp
+++ b/Tests/TestGuis/Uis/Navigation/UiNavigation.cpp
@@ -82,15 +82,15 @@ namespace test
 			if (m_currentTab != nullptr)
 			{
 				m_barBackground->SetColourOffset(m_currentTab->GetColour().Interpolate(m_targetTab->GetColour(), progress));
-				m_tabPuck->GetRectangle()->m_position->m_x = Maths::Interpolate(m_currentTab->GetRectangle()->m_position->m_x, m_targetTab->GetRectangle()->m_position->m_x, progress);
-				m_tabPuck->GetRectangle()->m_dimensions->m_x = Maths::Interpolate(m_currentTab->GetWidth(), m_targetTab->GetWidth(), progress);
+				m_tabPuck->GetRectangle()->m_position.m_x = Maths::Interpolate(m_currentTab->GetRectangle()->m_position.m_x, m_targetTab->GetRectangle()->m_position.m_x, progress);
+				m_tabPuck->GetRectangle()->m_dimensions.m_x = Maths::Interpolate(m_currentTab->GetWidth(), m_targetTab->GetWidth(), progress);
 			}
 			else
 			{
 				progress = 1.0f;
 				m_barBackground->SetColourOffset(m_targetTab->GetColour());
-				m_tabPuck->GetRectangle()->m_position->m_x = m_targetTab->GetRectangle()->m_position->m_x;
-				m_tabPuck->GetRectangle()->m_dimensions->m_x = m_targetTab->GetWidth();
+				m_tabPuck->GetRectangle()->m_position.m_x = m_targetTab->GetRectangle()->m_position.m_x;
+				m_tabPuck->GetRectangle()->m_dimensions.m_x = m_targetTab->GetWidth();
 			}
 
 			if (progress == 1.0f)

--- a/Tests/TestGuis/Uis/Navigation/UiNavigation.cpp
+++ b/Tests/TestGuis/Uis/Navigation/UiNavigation.cpp
@@ -47,7 +47,7 @@ namespace test
 			UiBound rectangle = UiBound(Vector2(tabXOffset, 0.955f), "TopLeft", false);
 			UiTab *uiTab = new UiTab(this, new ContentExit(this), rectangle, tabType.first, tabType.second);
 			tabXOffset += 0.03f + uiTab->GetWidth();
-			m_tabs.push_back(uiTab);
+			m_tabs.emplace_back(uiTab);
 
 			if (i == 0)
 			{

--- a/Tests/TestGuis/Uis/Navigation/UiTab.cpp
+++ b/Tests/TestGuis/Uis/Navigation/UiTab.cpp
@@ -11,7 +11,7 @@ namespace test
 		m_name(name),
 		m_colour(colour),
 		m_text(new Text(this, rectangle, 1.6f, name, Uis::Get()->m_proximaNova->GetRegular(), FontJustify::JUSTIFY_LEFT, 0.5f, 0.003f)),
-		m_width(m_text->GetRectangle()->m_dimensions->m_x * 1.6f),
+		m_width(m_text->GetRectangle()->m_dimensions.m_x * 1.6f),
 		m_soundClick(new Sound("Resources/Sounds/Button1.ogg", 0.9f))
 	{
 		this->SetActionLeft([&]()
@@ -32,8 +32,8 @@ namespace test
 
 	void UiTab::UpdateObject()
 	{
-		GetRectangle()->m_position->m_y = 1.0f;
-		*GetRectangle()->m_dimensions = *m_text->GetRectangle()->m_dimensions;
-		GetRectangle()->m_dimensions->m_y = 0.125f;
+		GetRectangle()->m_position.m_y = 1.0f;
+		GetRectangle()->m_dimensions = m_text->GetRectangle()->m_dimensions;
+		GetRectangle()->m_dimensions.m_y = 0.125f;
 	}
 }

--- a/Tests/TestGuis/Uis/OverlayDebug.cpp
+++ b/Tests/TestGuis/Uis/OverlayDebug.cpp
@@ -55,10 +55,10 @@ namespace test
 
 			if (Scenes::Get()->GetCamera() != nullptr)
 			{
-				Vector3 *cameraPosition = Scenes::Get()->GetCamera()->GetPosition();
-				m_textPosition->SetString("POS: " + std::to_string(static_cast<int>(cameraPosition->m_x)) + ", " +
-					std::to_string(static_cast<int>(cameraPosition->m_y)) + ", " +
-					std::to_string(static_cast<int>(cameraPosition->m_z)));
+				Vector3 cameraPosition = Scenes::Get()->GetCamera()->GetPosition();
+				m_textPosition->SetString("POS: " + std::to_string(static_cast<int>(cameraPosition.m_x)) + ", " +
+					std::to_string(static_cast<int>(cameraPosition.m_y)) + ", " +
+					std::to_string(static_cast<int>(cameraPosition.m_z)));
 			}
 
 			m_textFps->SetString("FPS: " + std::to_string(static_cast<int>(1.0 / Engine::Get()->GetDeltaRender())));

--- a/Tests/TestTerrain/MainRenderer.cpp
+++ b/Tests/TestTerrain/MainRenderer.cpp
@@ -78,8 +78,8 @@ namespace test
 		RENDERPASS_0_CREATE->SetWidth(Shadows::Get()->GetShadowSize());
 		RENDERPASS_0_CREATE->SetHeight(Shadows::Get()->GetShadowSize());
 
-		const auto commandBuffer = Renderer::Get()->GetCommandBuffer();
-		const auto camera = Scenes::Get()->GetCamera();
+		auto commandBuffer = Renderer::Get()->GetCommandBuffer();
+		auto camera = Scenes::Get()->GetCamera();
 
 		// Starts Rendering.
 		auto startResult = Renderer::Get()->StartRenderpass(*commandBuffer, 0);
@@ -98,8 +98,8 @@ namespace test
 
 	void MainRenderer::RenderPass1()
 	{
-		const auto commandBuffer = Renderer::Get()->GetCommandBuffer();
-		const auto camera = Scenes::Get()->GetCamera();
+		auto commandBuffer = Renderer::Get()->GetCommandBuffer();
+		auto camera = Scenes::Get()->GetCamera();
 
 		// Starts Rendering.
 		auto startResult = Renderer::Get()->StartRenderpass(*commandBuffer, 1);

--- a/Tests/TestTerrain/Scenes/FpsCamera.cpp
+++ b/Tests/TestTerrain/Scenes/FpsCamera.cpp
@@ -27,17 +27,17 @@ namespace test
 	const float FpsCamera::MIN_ANGLE_OF_ELEVATION = -85.0f;
 
 	FpsCamera::FpsCamera() :
-		m_position(new Vector3()),
-		m_velocity(new Vector3()),
-		m_rotation(new Vector3()),
-		m_viewMatrix(new Matrix4()),
-		m_projectionMatrix(new Matrix4()),
-		m_viewFrustum(new Frustum()),
-		m_viewRay(new Ray(false, Vector2(0.5f, 0.5f))),
+		m_position(Vector3()),
+		m_velocity(Vector3()),
+		m_rotation(Vector3()),
+		m_viewMatrix(Matrix4()),
+		m_projectionMatrix(Matrix4()),
+		m_viewFrustum(Frustum()),
+		m_viewRay(Ray(false, Vector2(0.5f, 0.5f))),
 		m_angleOfElevation(25.0f),
 		m_angleAroundPlayer(0.0f),
-		m_targetPosition(new Vector3()),
-		m_targetRotation(new Vector3()),
+		m_targetPosition(Vector3()),
+		m_targetRotation(Vector3()),
 		m_targetElevation(m_angleOfElevation),
 		m_targetRotationAngle(m_angleAroundPlayer),
 		m_sensitivity(0.9f),
@@ -50,19 +50,6 @@ namespace test
 
 	FpsCamera::~FpsCamera()
 	{
-		delete m_position;
-		delete m_velocity;
-		delete m_rotation;
-
-		delete m_viewMatrix;
-		delete m_projectionMatrix;
-
-		delete m_viewFrustum;
-		delete m_viewRay;
-
-		delete m_targetPosition;
-		delete m_targetRotation;
-
 		delete m_joystickVertical;
 		delete m_joystickHorizontal;
 	}
@@ -90,20 +77,20 @@ namespace test
 			auto playerRotation = player->GetGameObject()->GetTransform()->GetRotation();
 			auto playerPosition = player->GetGameObject()->GetTransform()->GetPosition();
 
-			*m_velocity = (*playerPosition - *m_targetPosition) / delta;
-			*m_targetPosition = *playerPosition;
-			*m_targetRotation = *playerRotation;
+			m_velocity = (playerPosition - m_targetPosition) / delta;
+			m_targetPosition = playerPosition;
+			m_targetRotation = playerRotation;
 		}
 
 		UpdateHorizontalAngle(delta);
 		UpdatePitchAngle(delta);
 		UpdatePosition();
 
-		*m_viewMatrix = Matrix4::ViewMatrix(*m_position, *m_rotation);
-		*m_projectionMatrix = Matrix4::PerspectiveMatrix(GetFov(), Display::Get()->GetAspectRatio(), GetNearPlane(), GetFarPlane());
+		m_viewMatrix = Matrix4::ViewMatrix(m_position, m_rotation);
+		m_projectionMatrix = Matrix4::PerspectiveMatrix(GetFov(), Display::Get()->GetAspectRatio(), GetNearPlane(), GetFarPlane());
 
-		m_viewFrustum->Update(*m_viewMatrix, *m_projectionMatrix);
-		m_viewRay->Update(*m_position, Vector2(Mouse::Get()->GetPositionX(), Mouse::Get()->GetPositionY()), *m_viewMatrix, *m_projectionMatrix);
+		m_viewFrustum.Update(m_viewMatrix, m_projectionMatrix);
+		m_viewRay.Update(m_position, Vector2(Mouse::Get()->GetPositionX(), Mouse::Get()->GetPositionY()), m_viewMatrix, m_projectionMatrix);
 	}
 
 	void FpsCamera::CalculateHorizontalAngle()
@@ -238,16 +225,16 @@ namespace test
 
 	void FpsCamera::UpdatePosition()
 	{
-		*m_position = *m_targetPosition;
-		m_rotation->m_x = m_angleOfElevation - m_targetRotation->m_z;
-		m_rotation->m_y = m_angleAroundPlayer + m_targetRotation->m_y + 180.0f;
-		m_rotation->m_z = 0.0f;
+		m_position = m_targetPosition;
+		m_rotation.m_x = m_angleOfElevation - m_targetRotation.m_z;
+		m_rotation.m_y = m_angleAroundPlayer + m_targetRotation.m_y + 180.0f;
+		m_rotation.m_z = 0.0f;
 	}
 
 	void FpsCamera::ReflectView(const float &waterHeight)
 	{
-		m_position->m_y -= 2.0f * (m_position->m_y - waterHeight);
-		m_rotation->m_x = -m_rotation->m_x;
-		*m_viewMatrix = Matrix4::ViewMatrix(*m_position, *m_rotation);
+		m_position.m_y -= 2.0f * (m_position.m_y - waterHeight);
+		m_rotation.m_x = -m_rotation.m_x;
+		m_viewMatrix = Matrix4::ViewMatrix(m_position, m_rotation);
 	}
 }

--- a/Tests/TestTerrain/Scenes/FpsCamera.cpp
+++ b/Tests/TestTerrain/Scenes/FpsCamera.cpp
@@ -231,9 +231,9 @@ namespace test
 		m_rotation.m_z = 0.0f;
 	}
 
-	void FpsCamera::ReflectView(const float &waterHeight)
+	void FpsCamera::ReflectView(const float &height)
 	{
-		m_position.m_y -= 2.0f * (m_position.m_y - waterHeight);
+		m_position.m_y -= 2.0f * (m_position.m_y - height);
 		m_rotation.m_x = -m_rotation.m_x;
 		m_viewMatrix = Matrix4::ViewMatrix(m_position, m_rotation);
 	}

--- a/Tests/TestTerrain/Scenes/FpsCamera.hpp
+++ b/Tests/TestTerrain/Scenes/FpsCamera.hpp
@@ -32,21 +32,21 @@ namespace test
 		static const float MAX_ANGLE_OF_ELEVATION;
 		static const float MIN_ANGLE_OF_ELEVATION;
 
-		Vector3 *m_position;
-		Vector3 *m_velocity;
-		Vector3 *m_rotation;
+		Vector3 m_position;
+		Vector3 m_velocity;
+		Vector3 m_rotation;
 
-		Matrix4 *m_viewMatrix;
-		Matrix4 *m_projectionMatrix;
+		Matrix4 m_viewMatrix;
+		Matrix4 m_projectionMatrix;
 
-		Frustum *m_viewFrustum;
-		Ray *m_viewRay;
+		Frustum m_viewFrustum;
+		Ray m_viewRay;
 
 		float m_angleOfElevation;
 		float m_angleAroundPlayer;
 
-		Vector3 *m_targetPosition;
-		Vector3 *m_targetRotation;
+		Vector3 m_targetPosition;
+		Vector3 m_targetRotation;
 		float m_targetElevation;
 		float m_targetRotationAngle;
 
@@ -83,18 +83,18 @@ namespace test
 
 		float GetFov() const override { return FIELD_OF_VIEW; }
 
-		Frustum *GetViewFrustum() const override { return m_viewFrustum; }
+		Frustum GetViewFrustum() const override { return m_viewFrustum; }
 
-		Ray *GetViewRay() const override { return m_viewRay; }
+		Ray GetViewRay() const override { return m_viewRay; }
 
-		Matrix4 *GetViewMatrix() const override { return m_viewMatrix; }
+		Matrix4 GetViewMatrix() const override { return m_viewMatrix; }
 
-		Matrix4 *GetProjectionMatrix() const override { return m_projectionMatrix; }
+		Matrix4 GetProjectionMatrix() const override { return m_projectionMatrix; }
 
-		Vector3 *GetPosition() const override { return m_position; }
+		Vector3 GetPosition() const override { return m_position; }
 
-		Vector3 *GetVelocity() const override { return m_velocity; }
+		Vector3 GetVelocity() const override { return m_velocity; }
 
-		Vector3 *GetRotation() const override { return m_rotation; }
+		Vector3 GetRotation() const override { return m_rotation; }
 	};
 }

--- a/Tests/TestTerrain/Scenes/FpsCamera.hpp
+++ b/Tests/TestTerrain/Scenes/FpsCamera.hpp
@@ -75,7 +75,7 @@ namespace test
 		void UpdatePosition();
 
 	public:
-		void ReflectView(const float &waterHeight) override;
+		void ReflectView(const float &height) override;
 
 		float GetNearPlane() const override { return NEAR_PLANE; }
 

--- a/Tests/TestTerrain/Scenes/FpsPlayer.cpp
+++ b/Tests/TestTerrain/Scenes/FpsPlayer.cpp
@@ -126,13 +126,13 @@ namespace test
 		*m_velocity = m_velocity->SmoothDamp(targetVelocity, delta * (m_noclipEnabled ? DAMP_NOCLIP : DAMP_NORMAL));
 
 		auto cameraRotation = Scenes::Get()->GetCamera()->GetRotation();
-		auto position = GetGameObject()->GetTransform()->GetPosition();
-		auto rotation = GetGameObject()->GetTransform()->GetRotation();
+		Vector3 newPosition = GetGameObject()->GetTransform()->GetPosition();
+		Vector3 newRotation = GetGameObject()->GetTransform()->GetRotation();
 
 		float groundHeight = 0.0f;
 
 		// Calculates the deltas to the moved distance, and rotation.
-		float theta = Maths::Radians(cameraRotation->m_y);
+		float theta = Maths::Radians(cameraRotation.m_y);
 		float dx = -(m_velocity->m_z * std::sin(theta) + m_velocity->m_x * std::cos(theta)) * delta;
 		float dy = m_velocity->m_y * delta;
 		float dz = -(m_velocity->m_z * std::cos(theta) - m_velocity->m_x * std::sin(theta)) * delta;
@@ -140,14 +140,17 @@ namespace test
 		*m_amountMove = Vector3(dx, dy, dz);
 		*m_amountRotate = Vector3(0.0f, 0.0f, 0.0f);
 
-		*position = *position + *m_amountMove;
-		*rotation = *rotation + *m_amountRotate;
+		newPosition += *m_amountMove;
+		newRotation += *m_amountRotate;
 
-		if (!m_noclipEnabled && position->m_y <= groundHeight)
+		if (!m_noclipEnabled && newPosition.m_y <= groundHeight)
 		{
 			m_velocity->m_y = 0.0f;
 			m_jumping = false;
-			position->m_y = groundHeight;
+			newPosition.m_y = groundHeight;
 		}
+
+		GetGameObject()->GetTransform()->SetPosition(newPosition);
+		GetGameObject()->GetTransform()->SetRotation(newRotation);
 	}
 }

--- a/Tests/TestTerrain/Scenes/ManagerUis.cpp
+++ b/Tests/TestTerrain/Scenes/ManagerUis.cpp
@@ -12,8 +12,8 @@ namespace test
 
 	ManagerUis::ManagerUis() :
 		IManagerUis(),
-		m_primaryColour(Colour("#e74c3c")),
-		m_selectorJoystick(SelectorJoystick(JoystickPort::JOYSTICK_1, 0, 1, 0, 1)),
+		m_primaryColour(new Colour("#e74c3c")),
+		m_selectorJoystick(new SelectorJoystick(JoystickPort::JOYSTICK_1, 0, 1, 0, 1)),
 		m_uiStartLogo(new UiStartLogo(Uis::Get()->GetContainer())),
 		m_overlayDebug(new OverlayDebug(Uis::Get()->GetContainer()))
 	{
@@ -23,6 +23,8 @@ namespace test
 
 	ManagerUis::~ManagerUis()
 	{
+		delete m_primaryColour;
+		delete m_selectorJoystick;
 		delete m_uiStartLogo;
 		delete m_overlayDebug;
 	}

--- a/Tests/TestTerrain/Scenes/ManagerUis.cpp
+++ b/Tests/TestTerrain/Scenes/ManagerUis.cpp
@@ -12,18 +12,17 @@ namespace test
 
 	ManagerUis::ManagerUis() :
 		IManagerUis(),
-		m_primaryColour(new Colour("#e74c3c")),
+		m_primaryColour(Colour("#e74c3c")),
+		m_selectorJoystick(SelectorJoystick(JoystickPort::JOYSTICK_1, 0, 1, 0, 1)),
 		m_uiStartLogo(new UiStartLogo(Uis::Get()->GetContainer())),
 		m_overlayDebug(new OverlayDebug(Uis::Get()->GetContainer()))
 	{
-		Uis::Get()->GetSelector()->Load(JoystickPort::JOYSTICK_1, 0, 1, 0, 1);
 		m_uiStartLogo->SetAlphaDriver(new DriverConstant(1.0f));
 		m_overlayDebug->SetAlphaDriver(new DriverConstant(0.0f));
 	}
 
 	ManagerUis::~ManagerUis()
 	{
-		delete m_primaryColour;
 		delete m_uiStartLogo;
 		delete m_overlayDebug;
 	}

--- a/Tests/TestTerrain/Scenes/ManagerUis.hpp
+++ b/Tests/TestTerrain/Scenes/ManagerUis.hpp
@@ -11,14 +11,15 @@ namespace test
 	class ManagerUis :
 		public IManagerUis
 	{
-	public:
-		static const float SLIDE_TIME;
 	private:
-		Colour *m_primaryColour;
+		Colour m_primaryColour;
+		SelectorJoystick m_selectorJoystick;
 
 		UiStartLogo *m_uiStartLogo;
 		OverlayDebug *m_overlayDebug;
 	public:
+		static const float SLIDE_TIME;
+
 		ManagerUis();
 
 		~ManagerUis();
@@ -29,6 +30,8 @@ namespace test
 
 		float GetBlurFactor() override;
 
-		Colour *GetPrimaryColour() override { return m_primaryColour; }
+		Colour GetPrimaryColour() const override { return m_primaryColour; }
+
+		SelectorJoystick GetSelectorJoystick() const override { return m_selectorJoystick; };
 	};
 }

--- a/Tests/TestTerrain/Scenes/ManagerUis.hpp
+++ b/Tests/TestTerrain/Scenes/ManagerUis.hpp
@@ -12,8 +12,8 @@ namespace test
 		public IManagerUis
 	{
 	private:
-		Colour m_primaryColour;
-		SelectorJoystick m_selectorJoystick;
+		Colour *m_primaryColour;
+		SelectorJoystick *m_selectorJoystick;
 
 		UiStartLogo *m_uiStartLogo;
 		OverlayDebug *m_overlayDebug;
@@ -30,8 +30,8 @@ namespace test
 
 		float GetBlurFactor() override;
 
-		Colour GetPrimaryColour() const override { return m_primaryColour; }
+		Colour *GetPrimaryColour() const override { return m_primaryColour; }
 
-		SelectorJoystick GetSelectorJoystick() const override { return m_selectorJoystick; };
+		SelectorJoystick *GetSelectorJoystick() const override { return m_selectorJoystick; };
 	};
 }

--- a/Tests/TestTerrain/Scenes/Scene1.cpp
+++ b/Tests/TestTerrain/Scenes/Scene1.cpp
@@ -80,7 +80,7 @@ namespace test
 		// Waters.
 		GameObject *water = new GameObject(Transform());
 		water->SetName("Water");
-		water->AddComponent<Mesh>(new MeshWater());
+		water->AddComponent<Mesh>(std::make_shared<MeshWater>());
 		water->AddComponent<MaterialWater>();
 		water->AddComponent<MeshRender>();
 

--- a/Tests/TestTerrain/Terrains/LodBehaviour.cpp
+++ b/Tests/TestTerrain/Terrains/LodBehaviour.cpp
@@ -9,7 +9,7 @@ namespace test
 {
 	LodBehaviour::LodBehaviour() :
 		Behaviour(),
-		m_modelLods(std::vector<Model *>()),
+		m_modelLods(std::vector<std::shared_ptr<Model>>()),
 		m_currentLod(5)
 	{
 		for (int i = 0; i < static_cast<int>(MeshTerrain::SQUARE_SIZES.size()); i++)
@@ -20,16 +20,12 @@ namespace test
 
 	LodBehaviour::~LodBehaviour()
 	{
-		for (auto model : m_modelLods)
-		{
-			delete model;
-		}
 	}
 
 	void LodBehaviour::Update()
 	{
-		Vector3 cameraPosition = Vector3(*Scenes::Get()->GetCamera()->GetPosition());
-		Vector3 chunkPosition = *GetGameObject()->GetTransform()->GetPosition();
+		Vector3 cameraPosition = Vector3(Scenes::Get()->GetCamera()->GetPosition());
+		Vector3 chunkPosition = GetGameObject()->GetTransform()->GetPosition();
 		float distance = std::fabs(chunkPosition.Distance(cameraPosition));
 
 		// lnreg{ (90.5, 0), (181, 1), (362, 2) } = int(-6.500 + 1.443 * log(x) / log(2.718)) + 1
@@ -70,7 +66,7 @@ namespace test
 		float textureScale = MeshTerrain::TEXTURE_SCALES.at(lod);
 		int vertexCount = CalculateVertexCount(MeshTerrain::SIDE_LENGTH, squareSize);
 		float lodFixScale = 1.0f; // (lod == 0) ? 1.0f : 1.02f + (0.028f * lod);
-		m_modelLods.at(lod) = new MeshTerrain(lodFixScale * static_cast<float>(MeshTerrain::SIDE_LENGTH), lodFixScale * squareSize, vertexCount, textureScale, GetGameObject()->GetTransform());
+		m_modelLods.at(lod) = std::make_shared<MeshTerrain>(lodFixScale * static_cast<float>(MeshTerrain::SIDE_LENGTH), lodFixScale * squareSize, vertexCount, textureScale, GetGameObject()->GetTransform());
 #if FL_VERBOSE
 		const auto debugEnd = Engine::Get()->GetTimeMs();
 

--- a/Tests/TestTerrain/Terrains/LodBehaviour.cpp
+++ b/Tests/TestTerrain/Terrains/LodBehaviour.cpp
@@ -14,7 +14,7 @@ namespace test
 	{
 		for (int i = 0; i < static_cast<int>(MeshTerrain::SQUARE_SIZES.size()); i++)
 		{
-			m_modelLods.push_back(nullptr);
+			m_modelLods.emplace_back(nullptr);
 		}
 	}
 
@@ -60,7 +60,7 @@ namespace test
 		}
 
 #if FL_VERBOSE
-		const auto debugStart = Engine::Get()->GetTimeMs();
+		float debugStart = Engine::Get()->GetTimeMs();
 #endif
 		float squareSize = MeshTerrain::SQUARE_SIZES.at(lod);
 		float textureScale = MeshTerrain::TEXTURE_SCALES.at(lod);
@@ -68,7 +68,7 @@ namespace test
 		float lodFixScale = 1.0f; // (lod == 0) ? 1.0f : 1.02f + (0.028f * lod);
 		m_modelLods.at(lod) = std::make_shared<MeshTerrain>(lodFixScale * static_cast<float>(MeshTerrain::SIDE_LENGTH), lodFixScale * squareSize, vertexCount, textureScale, GetGameObject()->GetTransform());
 #if FL_VERBOSE
-		const auto debugEnd = Engine::Get()->GetTimeMs();
+		float debugEnd = Engine::Get()->GetTimeMs();
 
 		if (debugEnd - debugStart > 22.0f)
 		{

--- a/Tests/TestTerrain/Terrains/LodBehaviour.hpp
+++ b/Tests/TestTerrain/Terrains/LodBehaviour.hpp
@@ -12,7 +12,7 @@ namespace test
 		public Behaviour
 	{
 	private:
-		std::vector<Model *> m_modelLods;
+		std::vector<std::shared_ptr<Model>> m_modelLods;
 		unsigned int m_currentLod;
 	public:
 		LodBehaviour();

--- a/Tests/TestTerrain/Terrains/MaterialTerrain.cpp
+++ b/Tests/TestTerrain/Terrains/MaterialTerrain.cpp
@@ -25,12 +25,12 @@ namespace test
 	{
 	}
 
-	void MaterialTerrain::PushUniforms(UniformHandler *uniformObject)
+	void MaterialTerrain::PushUniforms(UniformHandler &uniformObject)
 	{
-		uniformObject->Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
+		uniformObject.Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
 	}
 
-	void MaterialTerrain::PushDescriptors(DescriptorsHandler *descriptorSet)
+	void MaterialTerrain::PushDescriptors(DescriptorsHandler &descriptorSet)
 	{
 	}
 }

--- a/Tests/TestTerrain/Terrains/MaterialTerrain.hpp
+++ b/Tests/TestTerrain/Terrains/MaterialTerrain.hpp
@@ -13,7 +13,7 @@ namespace test
 		public IMaterial
 	{
 	private:
-		PipelineMaterial *m_material;
+		std::shared_ptr<PipelineMaterial> m_material;
 	public:
 		MaterialTerrain();
 
@@ -31,6 +31,6 @@ namespace test
 
 		std::string GetName() const override { return "MaterialTerrain"; };
 
-		PipelineMaterial *GetMaterial() const override { return m_material; }
+		std::shared_ptr<PipelineMaterial> GetMaterial() const override { return m_material; }
 	};
 }

--- a/Tests/TestTerrain/Terrains/MaterialTerrain.hpp
+++ b/Tests/TestTerrain/Terrains/MaterialTerrain.hpp
@@ -25,9 +25,9 @@ namespace test
 
 		void Write(LoadedValue *destination) override;
 
-		void PushUniforms(UniformHandler *uniformObject) override;
+		void PushUniforms(UniformHandler &uniformObject) override;
 
-		void PushDescriptors(DescriptorsHandler *descriptorSet) override;
+		void PushDescriptors(DescriptorsHandler &descriptorSet) override;
 
 		std::string GetName() const override { return "MaterialTerrain"; };
 

--- a/Tests/TestTerrain/Terrains/MeshTerrain.cpp
+++ b/Tests/TestTerrain/Terrains/MeshTerrain.cpp
@@ -34,13 +34,13 @@ namespace test
 	Vector3 MeshTerrain::GetPosition(const float &x, const float &z)
 	{
 		Vector3 position = Vector3(x, 0.0f, z);
-		position.m_y = GetHeight(position.m_x + m_transform->GetPosition()->m_x, position.m_z + m_transform->GetPosition()->m_z);
+		position.m_y = GetHeight(position.m_x + m_transform->GetPosition().m_x, position.m_z + m_transform->GetPosition().m_z);
 		return position;
 	}
 
 	Vector3 MeshTerrain::GetNormal(const Vector3 &position)
 	{
-		return GetNormal(position.m_x + m_transform->GetPosition()->m_x, position.m_z + m_transform->GetPosition()->m_z);
+		return GetNormal(position.m_x + m_transform->GetPosition().m_x, position.m_z + m_transform->GetPosition().m_z);
 	}
 
 	Vector3 MeshTerrain::GetColour(const Vector3 &position, const Vector3 &normal)
@@ -55,7 +55,7 @@ namespace test
 
 	float MeshTerrain::GetHeight(const float &x, const float &z)
 	{
-		float height1 = Worlds::Get()->GetNoiseTerrain()->GetNoise(x, z);
+		float height1 = Worlds::Get()->GetNoiseTerrain().GetNoise(x, z);
 		height1 = (height1 * 60.0f) + 15.0f;
 		//	float length = std::sqrt((x * x) + (z * z));
 

--- a/Tests/TestTerrain/Uis/OverlayDebug.cpp
+++ b/Tests/TestTerrain/Uis/OverlayDebug.cpp
@@ -55,10 +55,10 @@ namespace test
 
 			if (Scenes::Get()->GetCamera() != nullptr)
 			{
-				Vector3 *cameraPosition = Scenes::Get()->GetCamera()->GetPosition();
-				m_textPosition->SetString("POS: " + std::to_string(static_cast<int>(cameraPosition->m_x)) + ", " +
-					std::to_string(static_cast<int>(cameraPosition->m_y)) + ", " +
-					std::to_string(static_cast<int>(cameraPosition->m_z)));
+				Vector3 cameraPosition = Scenes::Get()->GetCamera()->GetPosition();
+				m_textPosition->SetString("POS: " + std::to_string(static_cast<int>(cameraPosition.m_x)) + ", " +
+					std::to_string(static_cast<int>(cameraPosition.m_y)) + ", " +
+					std::to_string(static_cast<int>(cameraPosition.m_z)));
 			}
 
 			m_textFps->SetString("FPS: " + std::to_string(static_cast<int>(1.0 / Engine::Get()->GetDeltaRender())));

--- a/Tests/TestTerrain/Voxels/MaterialVoxel.cpp
+++ b/Tests/TestTerrain/Voxels/MaterialVoxel.cpp
@@ -25,12 +25,12 @@ namespace test
 	{
 	}
 
-	void MaterialVoxel::PushUniforms(UniformHandler *uniformObject)
+	void MaterialVoxel::PushUniforms(UniformHandler &uniformObject)
 	{
-		uniformObject->Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
+		uniformObject.Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
 	}
 
-	void MaterialVoxel::PushDescriptors(DescriptorsHandler *descriptorSet)
+	void MaterialVoxel::PushDescriptors(DescriptorsHandler &descriptorSet)
 	{
 	}
 }

--- a/Tests/TestTerrain/Voxels/MaterialVoxel.hpp
+++ b/Tests/TestTerrain/Voxels/MaterialVoxel.hpp
@@ -13,7 +13,7 @@ namespace test
 		public IMaterial
 	{
 	private:
-		PipelineMaterial *m_material;
+		std::shared_ptr<PipelineMaterial> m_material;
 	public:
 		MaterialVoxel();
 
@@ -31,6 +31,6 @@ namespace test
 
 		std::string GetName() const override { return "MaterialVoxel"; };
 
-		PipelineMaterial *GetMaterial() const override { return m_material; }
+		std::shared_ptr<PipelineMaterial> GetMaterial() const override { return m_material; }
 	};
 }

--- a/Tests/TestTerrain/Voxels/MaterialVoxel.hpp
+++ b/Tests/TestTerrain/Voxels/MaterialVoxel.hpp
@@ -25,9 +25,9 @@ namespace test
 
 		void Write(LoadedValue *destination) override;
 
-		void PushUniforms(UniformHandler *uniformObject) override;
+		void PushUniforms(UniformHandler &uniformObject) override;
 
-		void PushDescriptors(DescriptorsHandler *descriptorSet) override;
+		void PushDescriptors(DescriptorsHandler &descriptorSet) override;
 
 		std::string GetName() const override { return "MaterialVoxel"; };
 

--- a/Tests/TestTerrain/Voxels/VoxelBlock.cpp
+++ b/Tests/TestTerrain/Voxels/VoxelBlock.cpp
@@ -4,7 +4,7 @@
 
 namespace test
 {
-	std::map<std::string, Colour *> VoxelBlock::s_colours = std::map<std::string, Colour *>
+	std::map<std::string, Colour *> VoxelBlock::BLOCK_COLOURS = std::map<std::string, Colour *>
 		{
 			{"",      new Colour("#FFFFFF", 0.0f)},
 			{"Grass", new Colour("#5E7831")},
@@ -31,15 +31,15 @@ namespace test
 
 	Colour *VoxelBlock::FindColour(const std::string &key)
 	{
-		const auto it = s_colours.find(key);
+		auto it = BLOCK_COLOURS.find(key);
 
-		if (it == s_colours.end())
+		if (it == BLOCK_COLOURS.end())
 		{
 #if FL_VERBOSE
 			printf("Could not find a Block Face colour from key: %s", key.c_str());
 #endif
 			auto colour = new Colour();
-			s_colours.insert(std::make_pair(key, colour));
+			BLOCK_COLOURS.emplace(key, colour);
 			return colour;
 		}
 

--- a/Tests/TestTerrain/Voxels/VoxelBlock.hpp
+++ b/Tests/TestTerrain/Voxels/VoxelBlock.hpp
@@ -23,7 +23,7 @@ namespace test
 	class VoxelBlock
 	{
 	private:
-		static std::map<std::string, Colour *> s_colours;
+		static std::map<std::string, Colour *> BLOCK_COLOURS;
 
 		VoxelChunk *m_parent;
 

--- a/Tests/TestTerrain/Voxels/VoxelChunk.cpp
+++ b/Tests/TestTerrain/Voxels/VoxelChunk.cpp
@@ -144,7 +144,7 @@ namespace test
 	void VoxelChunk::GenerateMesh()
 	{
 #if FL_VERBOSE
-		const auto debugStart = Engine::Get()->GetTimeMs();
+		float debugStart = Engine::Get()->GetTimeMs();
 #endif
 
 		auto mesh = GetGameObject()->GetComponent<Mesh>();
@@ -176,7 +176,7 @@ namespace test
 		}
 
 #if FL_VERBOSE
-		const auto debugEnd = Engine::Get()->GetTimeMs();
+		float debugEnd = Engine::Get()->GetTimeMs();
 
 		if (debugEnd - debugStart > 22.0f)
 		{
@@ -464,16 +464,16 @@ namespace test
 		}
 
 		// Pushes vertices and indices from quad.
-		vertices->push_back(new VertexModel(VOXEL_SIZE * bottomLeft, Vector2(), normal, colour));
-		vertices->push_back(new VertexModel(VOXEL_SIZE * topLeft, Vector2(), normal, colour));
-		vertices->push_back(new VertexModel(VOXEL_SIZE * bottomRight, Vector2(), normal, colour));
-		vertices->push_back(new VertexModel(VOXEL_SIZE * topRight, Vector2(), normal, colour));
+		vertices->emplace_back(new VertexModel(VOXEL_SIZE * bottomLeft, Vector2(), normal, colour));
+		vertices->emplace_back(new VertexModel(VOXEL_SIZE * topLeft, Vector2(), normal, colour));
+		vertices->emplace_back(new VertexModel(VOXEL_SIZE * bottomRight, Vector2(), normal, colour));
+		vertices->emplace_back(new VertexModel(VOXEL_SIZE * topRight, Vector2(), normal, colour));
 
-		indices->push_back(indexStart + 2);
-		indices->push_back(indexStart + (backFace ? 0 : 3));
-		indices->push_back(indexStart + 1);
-		indices->push_back(indexStart + 1);
-		indices->push_back(indexStart + (backFace ? 3 : 0));
-		indices->push_back(indexStart + 2);
+		indices->emplace_back(indexStart + 2);
+		indices->emplace_back(indexStart + (backFace ? 0 : 3));
+		indices->emplace_back(indexStart + 1);
+		indices->emplace_back(indexStart + 1);
+		indices->emplace_back(indexStart + (backFace ? 3 : 0));
+		indices->emplace_back(indexStart + 2);
 	}
 }

--- a/Tests/TestTerrain/Voxels/VoxelChunk.cpp
+++ b/Tests/TestTerrain/Voxels/VoxelChunk.cpp
@@ -106,7 +106,7 @@ namespace test
 
 	void VoxelChunk::Generate()
 	{
-		auto position = *GetGameObject()->GetTransform()->GetPosition() / VOXEL_SIZE;
+		auto position = GetGameObject()->GetTransform()->GetPosition() / VOXEL_SIZE;
 		//	auto noise = Worlds::Get()->GetNoise();
 
 		for (int x = 0; x < CHUNK_WIDTH; x++)
@@ -167,11 +167,11 @@ namespace test
 			break;
 		}
 
-		delete mesh->GetModel();
+	// 	delete mesh->GetModel();
 
 		if (!vertices.empty() || !indices.empty())
 		{
-			Model *model = new Model(vertices, indices, GetName());
+			auto model = std::make_shared<Model>(vertices, indices, GetName());
 			mesh->SetModel(model);
 		}
 

--- a/Tests/TestTerrain/Waters/MaterialWater.cpp
+++ b/Tests/TestTerrain/Waters/MaterialWater.cpp
@@ -29,13 +29,13 @@ namespace test
 	{
 	}
 
-	void MaterialWater::PushUniforms(UniformHandler *uniformObject)
+	void MaterialWater::PushUniforms(UniformHandler &uniformObject)
 	{
-		uniformObject->Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
-		uniformObject->Push("diffuseColour", m_colour);
+		uniformObject.Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
+		uniformObject.Push("diffuseColour", m_colour);
 	}
 
-	void MaterialWater::PushDescriptors(DescriptorsHandler *descriptorSet)
+	void MaterialWater::PushDescriptors(DescriptorsHandler &descriptorSet)
 	{
 	}
 }

--- a/Tests/TestTerrain/Waters/MaterialWater.cpp
+++ b/Tests/TestTerrain/Waters/MaterialWater.cpp
@@ -6,7 +6,7 @@ namespace test
 {
 	MaterialWater::MaterialWater() :
 		IMaterial(),
-		m_colour(new Colour(MeshWater::WATER_COLOUR)),
+		m_colour(Colour(MeshWater::WATER_COLOUR)),
 		m_material(PipelineMaterial::Resource({1, 0}, PipelineCreate({"Resources/Shaders/Waters/Water.vert", "Resources/Shaders/Waters/Water.frag"},
 			VertexModel::GetVertexInput(), PIPELINE_MODE_MRT, PIPELINE_POLYGON_MODE_FILL, PIPELINE_CULL_MODE_BACK), {}))
 	{
@@ -14,11 +14,11 @@ namespace test
 
 	MaterialWater::~MaterialWater()
 	{
-		delete m_colour;
 	}
 
 	void MaterialWater::Update()
 	{
+		m_colour.m_a = 1.0f; // Waters::Get()->GetEnableReflections() ? Waters::Get()->GetColourIntensity() : 1.0f
 	}
 
 	void MaterialWater::Load(LoadedValue *value)
@@ -32,7 +32,7 @@ namespace test
 	void MaterialWater::PushUniforms(UniformHandler *uniformObject)
 	{
 		uniformObject->Push("transform", GetGameObject()->GetTransform()->GetWorldMatrix());
-		uniformObject->Push("diffuseColour", Colour(m_colour->m_r, m_colour->m_g, m_colour->m_b, 1.0f)); // Waters::Get()->GetEnableReflections() ? Waters::Get()->GetColourIntensity() : 1.0f
+		uniformObject->Push("diffuseColour", m_colour);
 	}
 
 	void MaterialWater::PushDescriptors(DescriptorsHandler *descriptorSet)

--- a/Tests/TestTerrain/Waters/MaterialWater.hpp
+++ b/Tests/TestTerrain/Waters/MaterialWater.hpp
@@ -14,9 +14,9 @@ namespace test
 		public IMaterial
 	{
 	private:
-		Colour *m_colour;
+		Colour m_colour;
 
-		PipelineMaterial *m_material;
+		std::shared_ptr<PipelineMaterial> m_material;
 	public:
 		MaterialWater();
 
@@ -34,10 +34,10 @@ namespace test
 
 		std::string GetName() const override { return "MaterialWater"; };
 
-		Colour *GetColour() const { return m_colour; }
+		Colour GetColour() const { return m_colour; }
 
-		void SetColour(const Colour &colour) const { *m_colour = colour; }
+		void SetColour(const Colour &colour) { m_colour = colour; }
 
-		PipelineMaterial *GetMaterial() const override { return m_material; }
+		std::shared_ptr<PipelineMaterial> GetMaterial() const override { return m_material; }
 	};
 }

--- a/Tests/TestTerrain/Waters/MaterialWater.hpp
+++ b/Tests/TestTerrain/Waters/MaterialWater.hpp
@@ -28,9 +28,9 @@ namespace test
 
 		void Write(LoadedValue *destination) override;
 
-		void PushUniforms(UniformHandler *uniformObject) override;
+		void PushUniforms(UniformHandler &uniformObject) override;
 
-		void PushDescriptors(DescriptorsHandler *descriptorSet) override;
+		void PushDescriptors(DescriptorsHandler &descriptorSet) override;
 
 		std::string GetName() const override { return "MaterialWater"; };
 


### PR DESCRIPTION
Significantly reduced dynamic allocations, a reduction proposed in issue https://github.com/Equilibrium-Games/Flounder/issues/9. Resources and mult-use objects now use shared pointers for memory management, and other significant code cleanups.

The following folders and objects still need cleaning:
```
Animations/
Files/
Materials/PipelineMaterial.hpp
Models/
Renderer/
Objects/GameObject.hpp
Scenes/
Uis/
```